### PR TITLE
npm run typegen - generate TypeScript declaration files

### DIFF
--- a/dist/types/env.d.ts
+++ b/dist/types/env.d.ts
@@ -1,0 +1,14 @@
+export namespace env {
+    export { onnx_env as onnx };
+    export const remoteModels: boolean;
+    export const remoteURL: string;
+    export { localURL };
+    export { CACHE_AVAILABLE as useCache };
+    export { FS_AVAILABLE as useFS };
+}
+import onnx_env_1 = require("onnxruntime-common/dist/lib/env");
+import onnx_env = onnx_env_1.env;
+declare const localURL: string;
+declare const CACHE_AVAILABLE: boolean;
+declare const FS_AVAILABLE: boolean;
+export {};

--- a/dist/types/fft.d.ts
+++ b/dist/types/fft.d.ts
@@ -1,0 +1,22 @@
+export = FFT;
+declare class FFT {
+    constructor(size: any);
+    size: number;
+    _csize: number;
+    table: Float64Array;
+    _width: number;
+    _bitrev: Int32Array;
+    createComplexArray(): Float64Array;
+    fromComplexArray(complex: any, storage: any): any;
+    toComplexArray(input: any, storage: any): any;
+    completeSpectrum(spectrum: any): void;
+    transform(out: any, data: any): void;
+    realTransform(out: any, data: any): void;
+    inverseTransform(out: any, data: any): void;
+    _transform4(out: any, data: any, inv: any): void;
+    _singleTransform2(data: any, out: any, outOff: any, off: any, step: any): void;
+    _singleTransform4(data: any, out: any, outOff: any, off: any, step: any, inv: any): void;
+    _realTransform4(out: any, data: any, inv: any): void;
+    _singleRealTransform2(data: any, out: any, outOff: any, off: any, step: any): void;
+    _singleRealTransform4(data: any, out: any, outOff: any, off: any, step: any, inv: any): void;
+}

--- a/dist/types/models.d.ts
+++ b/dist/types/models.d.ts
@@ -1,0 +1,263 @@
+export class AutoModel {
+    static from_pretrained(modelPath: any, progressCallback?: any): Promise<PreTrainedModel | T5Model | GPT2Model | CodeGenModel | BartModel | WhisperModel>;
+}
+export class AutoModelForSeq2SeqLM {
+    static from_pretrained(modelPath: any, progressCallback?: any): Promise<T5ForConditionalGeneration | BartForConditionalGeneration | WhisperForConditionalGeneration>;
+}
+export class AutoModelForSequenceClassification {
+    static from_pretrained(modelPath: any, progressCallback?: any): Promise<BertForSequenceClassification | AlbertForSequenceClassification | DistilBertForSequenceClassification | RobertaForSequenceClassification>;
+}
+export class AutoModelForCausalLM {
+    static from_pretrained(modelPath: any, progressCallback?: any): Promise<GPT2LMHeadModel | CodeGenForCausalLM>;
+}
+export class AutoModelForMaskedLM {
+    static from_pretrained(modelPath: any, progressCallback?: any): Promise<PreTrainedModel>;
+}
+export class AutoModelForQuestionAnswering {
+    static from_pretrained(modelPath: any, progressCallback?: any): Promise<BertForQuestionAnswering | AlbertForQuestionAnswering | DistilBertForQuestionAnswering | RobertaForQuestionAnswering>;
+}
+export class AutoModelForVision2Seq {
+    static from_pretrained(modelPath: any, progressCallback?: any): Promise<VisionEncoderDecoderModel>;
+}
+export class AutoModelForImageClassification {
+    static from_pretrained(modelPath: any, progressCallback?: any): Promise<ViTForImageClassification>;
+}
+export class T5ForConditionalGeneration extends T5PreTrainedModel {
+    static from_pretrained(modelPath: any, progressCallback?: any): Promise<T5ForConditionalGeneration>;
+    constructor(config: any, session: any, decoder_merged_session: any);
+    decoder_merged_session: any;
+    num_decoder_layers: any;
+    num_decoder_heads: any;
+    decoder_dim_kv: any;
+    num_encoder_layers: any;
+    num_encoder_heads: any;
+    encoder_dim_kv: any;
+    getStartBeams(inputs: any, numOutputTokens: any, ...args: any[]): {
+        inputs: any;
+        encoder_outputs: any;
+        past_key_values: any;
+        output_token_ids: any[];
+        done: boolean;
+        score: number;
+        id: number;
+    }[];
+    runBeam(beam: any): Promise<any>;
+    updateBeam(beam: any, newTokenId: any): void;
+    forward(model_inputs: any): Promise<Seq2SeqLMOutput>;
+}
+declare class PreTrainedModel extends Callable {
+    static from_pretrained(modelPath: any, progressCallback?: any): Promise<PreTrainedModel>;
+    constructor(config: any, session: any);
+    config: any;
+    session: any;
+    default_generation_options: {
+        max_new_tokens: number;
+        top_k: number;
+        num_beams: number;
+        temperature: number;
+        num_return_sequences: number;
+        early_stopping: boolean;
+        do_sample: boolean;
+        callback_function: any;
+    };
+    forced_decoder_ids_mapping: {
+        [k: string]: any;
+    };
+    dispose(): Promise<any[]>;
+    toI64Tensor(items: any): Tensor;
+    _call(model_inputs: any): Promise<any>;
+    forward(model_inputs: any): Promise<void>;
+    generate(inputs: any, options?: {}, inputs_attention_mask?: any): Promise<any[]>;
+    groupBeams(beams: any): any[];
+    prepareGenerationOptions(options: any): any;
+    getPastKeyValues(decoderResults: any): {};
+    addPastKeyValues(decoderFeeds: any, pastKeyValues: any, hasDecoder?: boolean): void;
+}
+declare class T5Model extends T5PreTrainedModel {
+    generate(...args: any[]): Promise<void>;
+}
+declare class GPT2Model extends GPT2PreTrainedModel {
+    generate(...args: any[]): Promise<void>;
+}
+declare class CodeGenModel extends CodeGenPreTrainedModel {
+    generate(...args: any[]): Promise<void>;
+}
+declare class BartModel extends BartPretrainedModel {
+    generate(...args: any[]): Promise<void>;
+}
+declare class WhisperModel extends WhisperPreTrainedModel {
+    generate(...args: any[]): Promise<void>;
+}
+declare class BartForConditionalGeneration extends BartPretrainedModel {
+    static from_pretrained(modelPath: any, progressCallback?: any): Promise<BartForConditionalGeneration>;
+    constructor(config: any, session: any, decoder_merged_session: any);
+    decoder_merged_session: any;
+    num_decoder_layers: any;
+    num_decoder_heads: any;
+    decoder_dim_kv: number;
+    num_encoder_layers: any;
+    num_encoder_heads: any;
+    encoder_dim_kv: number;
+    getStartBeams(inputs: any, numOutputTokens: any, ...args: any[]): {
+        inputs: any;
+        encoder_outputs: any;
+        past_key_values: any;
+        output_token_ids: any[];
+        done: boolean;
+        score: number;
+        id: number;
+    }[];
+    runBeam(beam: any): Promise<any>;
+    updateBeam(beam: any, newTokenId: any): void;
+    forward(model_inputs: any): Promise<Seq2SeqLMOutput>;
+}
+declare class WhisperForConditionalGeneration extends WhisperPreTrainedModel {
+    static from_pretrained(modelPath: any, progressCallback?: any): Promise<WhisperForConditionalGeneration>;
+    constructor(config: any, session: any, decoder_merged_session: any);
+    decoder_merged_session: any;
+    num_decoder_layers: any;
+    num_decoder_heads: any;
+    decoder_dim_kv: number;
+    num_encoder_layers: any;
+    num_encoder_heads: any;
+    encoder_dim_kv: number;
+    getStartBeams(inputTokenIds: any, numOutputTokens: any, ...args: any[]): {
+        inputs: any;
+        encoder_outputs: any;
+        past_key_values: any;
+        output_token_ids: any[];
+        done: boolean;
+        score: number;
+        id: number;
+    }[];
+    runBeam(beam: any): Promise<any>;
+    updateBeam(beam: any, newTokenId: any): void;
+    forward(model_inputs: any): Promise<Seq2SeqLMOutput>;
+}
+declare class BertForSequenceClassification extends BertPreTrainedModel {
+    _call(model_inputs: any): Promise<SequenceClassifierOutput>;
+}
+declare class AlbertForSequenceClassification extends AlbertPreTrainedModel {
+    _call(model_inputs: any): Promise<SequenceClassifierOutput>;
+}
+declare class DistilBertForSequenceClassification extends DistilBertPreTrainedModel {
+    _call(model_inputs: any): Promise<SequenceClassifierOutput>;
+}
+declare class RobertaForSequenceClassification extends RobertaPreTrainedModel {
+    _call(model_inputs: any): Promise<SequenceClassifierOutput>;
+}
+declare class GPT2LMHeadModel extends GPT2PreTrainedModel {
+    num_heads: any;
+    num_layers: any;
+    dim_kv: number;
+    getStartBeams(inputTokenIds: any, numOutputTokens: any, inputs_attention_mask: any): {
+        input: any;
+        model_input_ids: any;
+        attention_mask: any;
+        past_key_values: any;
+        output_token_ids: any[];
+        num_output_tokens: any;
+        done: boolean;
+        score: number;
+        id: number;
+    }[];
+    runBeam(beam: any): Promise<any>;
+    updateBeam(beam: any, newTokenId: any): void;
+    forward(model_inputs: any): Promise<{
+        logits: any;
+        past_key_values: any;
+    }>;
+}
+declare class CodeGenForCausalLM extends CodeGenPreTrainedModel {
+    num_heads: any;
+    num_layers: any;
+    dim_kv: number;
+    getStartBeams(inputTokenIds: any, numOutputTokens: any, inputs_attention_mask: any): {
+        input: any;
+        model_input_ids: any;
+        attention_mask: any;
+        past_key_values: any;
+        output_token_ids: any[];
+        num_output_tokens: any;
+        done: boolean;
+        score: number;
+        id: number;
+    }[];
+    runBeam(beam: any): Promise<any>;
+    updateBeam(beam: any, newTokenId: any): void;
+    forward(model_inputs: any): Promise<{
+        logits: any;
+        past_key_values: any;
+    }>;
+}
+declare class BertForQuestionAnswering extends BertPreTrainedModel {
+    _call(model_inputs: any): Promise<QuestionAnsweringModelOutput>;
+}
+declare class AlbertForQuestionAnswering extends AlbertPreTrainedModel {
+    _call(model_inputs: any): Promise<QuestionAnsweringModelOutput>;
+}
+declare class DistilBertForQuestionAnswering extends DistilBertPreTrainedModel {
+    _call(model_inputs: any): Promise<QuestionAnsweringModelOutput>;
+}
+declare class RobertaForQuestionAnswering extends RobertaPreTrainedModel {
+    _call(model_inputs: any): Promise<QuestionAnsweringModelOutput>;
+}
+declare class VisionEncoderDecoderModel extends PreTrainedModel {
+    static from_pretrained(modelPath: any, progressCallback?: any): Promise<VisionEncoderDecoderModel>;
+    constructor(config: any, session: any, decoder_merged_session: any);
+    decoder_merged_session: any;
+    num_layers: any;
+    num_heads: any;
+    dim_kv: number;
+    getStartBeams(inputs: any, numOutputTokens: any, ...args: any[]): {
+        inputs: any;
+        encoder_outputs: any;
+        past_key_values: any;
+        output_token_ids: any[];
+        done: boolean;
+        score: number;
+        id: number;
+    }[];
+    runBeam(beam: any): Promise<any>;
+    updateBeam(beam: any, newTokenId: any): void;
+    forward(model_inputs: any): Promise<Seq2SeqLMOutput>;
+}
+declare class ViTForImageClassification extends PreTrainedModel {
+    _call(model_inputs: any): Promise<SequenceClassifierOutput>;
+}
+declare class T5PreTrainedModel extends PreTrainedModel {
+}
+declare class Seq2SeqLMOutput {
+    constructor(logits: any, past_key_values: any, encoder_outputs: any);
+    logits: any;
+    past_key_values: any;
+    encoder_outputs: any;
+}
+import { Callable } from "./utils.js";
+import { Tensor } from "./tensor_utils.js";
+declare class GPT2PreTrainedModel extends PreTrainedModel {
+}
+declare class CodeGenPreTrainedModel extends PreTrainedModel {
+}
+declare class BartPretrainedModel extends PreTrainedModel {
+}
+declare class WhisperPreTrainedModel extends PreTrainedModel {
+}
+declare class BertPreTrainedModel extends PreTrainedModel {
+}
+declare class SequenceClassifierOutput {
+    constructor(logits: any);
+    logits: any;
+}
+declare class AlbertPreTrainedModel extends PreTrainedModel {
+}
+declare class DistilBertPreTrainedModel extends PreTrainedModel {
+}
+declare class RobertaPreTrainedModel extends PreTrainedModel {
+}
+declare class QuestionAnsweringModelOutput {
+    constructor(start_logits: any, end_logits: any);
+    start_logits: any;
+    end_logits: any;
+}
+export {};

--- a/dist/types/pipelines.d.ts
+++ b/dist/types/pipelines.d.ts
@@ -1,0 +1,3 @@
+export function pipeline(task: any, model?: any, { progress_callback }?: {
+    progress_callback?: any;
+}): Promise<any>;

--- a/dist/types/processors.d.ts
+++ b/dist/types/processors.d.ts
@@ -1,0 +1,12 @@
+export class AutoProcessor {
+    static from_pretrained(modelPath: any, progressCallback?: any): Promise<WhisperProcessor>;
+}
+declare class WhisperProcessor extends Processor {
+}
+declare class Processor extends Callable {
+    constructor(feature_extractor: any);
+    feature_extractor: any;
+    _call(input: any): Promise<any>;
+}
+import { Callable } from "./utils.js";
+export {};

--- a/dist/types/samplers.d.ts
+++ b/dist/types/samplers.d.ts
@@ -1,0 +1,25 @@
+export class Sampler extends Callable {
+    static getSampler(options: any): BeamSearchSampler | TopKSampler | GreedySampler;
+    constructor(temperature: any);
+    temperature: any;
+    _call(logits: any, index?: number): void;
+    sample(logits: any, index: any): void;
+    getLogits(logits: any, index: any): any;
+    randomSelect(probabilities: any): number;
+}
+export class GreedySampler extends Sampler {
+    sample(logits: any, index?: number): number[][];
+}
+export class TopKSampler extends Sampler {
+    constructor(temperature: any, k: any);
+    k: any;
+    sample(logits: any, index?: number): any[][];
+}
+export class BeamSearchSampler extends Sampler {
+    constructor(temperature: any, num_beams: any, do_sample: any, top_k: any);
+    num_beams: any;
+    do_sample: any;
+    top_k: any;
+    sample(logits: any, index?: number): any;
+}
+import { Callable } from "./utils.js";

--- a/dist/types/tensor_utils.d.ts
+++ b/dist/types/tensor_utils.d.ts
@@ -1,0 +1,21 @@
+export class Tensor extends ONNX.TypedTensor<"string"> {
+    constructor(...args: any[]);
+    /**
+     *
+     * @param {number} index
+     * @returns
+     */
+    get(index: number): string | Tensor;
+    indexOf(item: any): number;
+    /**
+     * @param {number} index
+     * @param {number} iterSize
+     * @param {number} iterDims
+     * @returns {this}
+     */
+    _subarray(index: number, iterSize: number, iterDims: number): this;
+    [Symbol.iterator](): Generator<string | Tensor, void, undefined>;
+}
+export function transpose(tensor: any, axes: any): Tensor;
+export function cat(tensors: any): any;
+import ONNX = require("onnxruntime-web");

--- a/dist/types/tokenizers.d.ts
+++ b/dist/types/tokenizers.d.ts
@@ -1,0 +1,237 @@
+export class AutoTokenizer {
+    static from_pretrained(modelPath: any, progressCallback?: any): Promise<PreTrainedTokenizer>;
+}
+export class BertTokenizer extends PreTrainedTokenizer {
+}
+export class DistilBertTokenizer extends PreTrainedTokenizer {
+}
+export class T5Tokenizer extends PreTrainedTokenizer {
+}
+export class GPT2Tokenizer extends PreTrainedTokenizer {
+}
+declare class PreTrainedTokenizer extends Callable {
+    static from_pretrained(modelPath: any, progressCallback?: any): Promise<PreTrainedTokenizer>;
+    constructor(tokenizerJSON: any, tokenizerConfig: any);
+    tokenizerJSON: any;
+    tokenizerConfig: any;
+    normalizer: BertNormalizer | Precompiled | NormalizerSequence | Replace | NFC | NFKD | StripAccents | Lowercase;
+    pre_tokenizer: BertPreTokenizer | PreTokenizerSequence | WhitespaceSplit | MetaspacePreTokenizer | ByteLevelPreTokenizer | SplitPreTokenizer;
+    model: WordPieceTokenizer | Unigram | BPE;
+    post_processor: TemplateProcessing | ByteLevelPostProcessor | RobertaProcessing;
+    decoder: WordPieceDecoder | MetaspaceDecoder | ByteLevelDecoder;
+    special_tokens: any[];
+    all_special_ids: any[];
+    special_tokens_regex: RegExp;
+    mask_token: any;
+    mask_token_id: any;
+    pad_token: any;
+    pad_token_id: any;
+    sep_token: any;
+    sep_token_id: any;
+    model_max_length: any;
+    remove_space: any;
+    padding_side: string;
+    getToken(...keys: any[]): any;
+    prepare_model_inputs(inputs: any): any;
+    _call(text: any, { text_pair, padding, truncation, max_length, return_tensor, }?: {
+        text_pair?: any;
+        padding?: boolean;
+        truncation?: any;
+        max_length?: any;
+        return_tensor?: boolean;
+    }): {
+        input_ids: any[] | Tensor;
+        attention_mask: any[];
+    };
+    _encode_text(text: any): any;
+    encode(text: any, text_pair?: any): any;
+    clean_up_tokenization(text: any): any;
+    batch_decode(batch: any, decode_args?: {}): any;
+    decode(token_ids: any, decode_args?: {}): any;
+    decode_single(token_ids: any, { skip_special_tokens, clean_up_tokenization_spaces, }: {
+        skip_special_tokens?: boolean;
+        clean_up_tokenization_spaces?: boolean;
+    }): any;
+}
+import { Callable } from "./utils.js";
+declare class BertNormalizer extends Normalizer {
+    stripAccents(text: any): any;
+    normalize(text: any): any;
+}
+declare class Precompiled extends Normalizer {
+    charsmap: any;
+    normalize(text: any): any;
+}
+declare class NormalizerSequence extends Normalizer {
+    normalizers: any;
+    normalize(text: any): any;
+}
+declare class Replace extends Normalizer {
+    normalize(text: any): any;
+}
+declare class NFC extends Normalizer {
+    normalize(text: any): any;
+}
+declare class NFKD extends Normalizer {
+    normalize(text: any): any;
+}
+declare class StripAccents extends Normalizer {
+    normalize(text: any): any;
+}
+declare class Lowercase extends Normalizer {
+    normalize(text: any): any;
+}
+declare class BertPreTokenizer extends PreTokenizer {
+    constructor(config: any);
+    pattern: RegExp;
+    pre_tokenize_text(text: any): any;
+}
+declare class PreTokenizerSequence extends PreTokenizer {
+    constructor(config: any);
+    tokenizers: any;
+    pre_tokenize_text(text: any): any;
+}
+declare class WhitespaceSplit extends PreTokenizer {
+    constructor(config: any);
+    pre_tokenize_text(text: any): any;
+}
+declare class MetaspacePreTokenizer extends PreTokenizer {
+    constructor(config: any);
+    addPrefixSpace: any;
+    replacement: any;
+    strRep: any;
+}
+declare class ByteLevelPreTokenizer extends PreTokenizer {
+    constructor(config: any);
+    pattern: RegExp;
+    pre_tokenize_text(text: any): any;
+}
+declare class SplitPreTokenizer extends PreTokenizer {
+    constructor(config: any);
+    config: any;
+    pre_tokenize_text(text: any): any;
+}
+declare class WordPieceTokenizer extends TokenizerModel {
+    tokens_to_ids: any;
+    unk_token_id: any;
+    unk_token: any;
+    vocab: any[];
+    encode(tokens: any): any[];
+}
+declare class Unigram extends TokenizerModel {
+    constructor(config: any, moreConfig: any);
+    vocab: any;
+    scores: any;
+    unk_token_id: any;
+    unk_token: any;
+    tokens_to_ids: {
+        [k: string]: any;
+    };
+    bosToken: string;
+    bosTokenId: any;
+    eosToken: any;
+    eosTokenId: any;
+    unkToken: any;
+    minScore: number;
+    unkScore: number;
+    trie: CharTrie;
+    populateNodes(lattice: any): void;
+    tokenize(normalized: any): any[];
+    encode(tokens: any): any[];
+}
+declare class BPE extends TokenizerModel {
+    tokens_to_ids: any;
+    unk_token_id: any;
+    unk_token: any;
+    vocab: any[];
+    bpe_ranks: {
+        [k: string]: any;
+    };
+    merges: any;
+    byte_encoder: {
+        [k: string]: number;
+    };
+    text_encoder: TextEncoder;
+    cache: {};
+    get_pairs(word: any): any[];
+    bpe(token: any): any;
+    encode(tokens: any): any[];
+}
+declare class TemplateProcessing extends PostProcessor {
+    constructor(config: any);
+    config: any;
+    post_process(tokens: any, tokens_pair?: any): any[];
+}
+declare class ByteLevelPostProcessor extends PostProcessor {
+    constructor(config: any);
+    config: any;
+    post_process(tokens: any): any;
+}
+declare class RobertaProcessing extends PostProcessor {
+    constructor(config: any);
+    config: any;
+    post_process(tokens: any, tokens_pair?: any): any;
+}
+declare class WordPieceDecoder extends Decoder {
+    convertRegex: RegExp;
+    decode(tokens: any): any;
+}
+declare class MetaspaceDecoder extends Decoder {
+    addPrefixSpace: any;
+    replacement: any;
+    decode(tokens: any): any;
+}
+declare class ByteLevelDecoder extends Decoder {
+    byte_decoder: any;
+    text_decoder: TextDecoder;
+    convert_tokens_to_string(tokens: any): string;
+    decode(tokens: any): string;
+}
+import { Tensor } from "./tensor_utils.js";
+declare class Normalizer extends Callable {
+    static fromConfig(config: any): BertNormalizer | Precompiled | NormalizerSequence | Replace | NFC | NFKD | StripAccents | Lowercase;
+    constructor(config: any);
+    config: any;
+    normalize(text: any): void;
+    _call(text: any): void;
+}
+declare class PreTokenizer extends Callable {
+    static fromConfig(config: any): BertPreTokenizer | PreTokenizerSequence | WhitespaceSplit | MetaspacePreTokenizer | ByteLevelPreTokenizer | SplitPreTokenizer;
+    pre_tokenize_text(text: any): void;
+    pre_tokenize(text: any): any[];
+    _call(text: any): any[];
+}
+declare class TokenizerModel extends Callable {
+    static fromConfig(config: any, ...args: any[]): WordPieceTokenizer | Unigram | BPE;
+    constructor(config: any);
+    config: any;
+    _call(tokens: any): void;
+    encode(tokens: any): void;
+    convert_tokens_to_ids(tokens: any): any;
+    convert_ids_to_tokens(ids: any): any;
+}
+declare class CharTrie {
+    root: CharTrieNode;
+    push(...texts: any[]): void;
+    commonPrefixSearch(text: any): Generator<string, void, unknown>;
+}
+declare class PostProcessor extends Callable {
+    static fromConfig(config: any): TemplateProcessing | ByteLevelPostProcessor | RobertaProcessing;
+    post_process(tokens: any, ...args: any[]): void;
+    _call(tokens: any, ...args: any[]): void;
+}
+declare class Decoder extends Callable {
+    static fromConfig(config: any): WordPieceDecoder | MetaspaceDecoder | ByteLevelDecoder;
+    constructor(config: any);
+    config: any;
+    convert_tokens_to_string(tokens: any): any;
+    _call(tokens: any): void;
+    decode(tokens: any): void;
+}
+declare class CharTrieNode {
+    static default(): CharTrieNode;
+    constructor(isLeaf: any, children: any);
+    isLeaf: any;
+    children: any;
+}
+export {};

--- a/dist/types/transformers.d.ts
+++ b/dist/types/transformers.d.ts
@@ -1,0 +1,18 @@
+import { AutoTokenizer } from "./tokenizers.js";
+import { BertTokenizer } from "./tokenizers.js";
+import { DistilBertTokenizer } from "./tokenizers.js";
+import { T5Tokenizer } from "./tokenizers.js";
+import { GPT2Tokenizer } from "./tokenizers.js";
+import { AutoModel } from "./models.js";
+import { AutoModelForSeq2SeqLM } from "./models.js";
+import { AutoModelForSequenceClassification } from "./models.js";
+import { AutoModelForCausalLM } from "./models.js";
+import { AutoModelForMaskedLM } from "./models.js";
+import { AutoModelForQuestionAnswering } from "./models.js";
+import { AutoModelForVision2Seq } from "./models.js";
+import { AutoModelForImageClassification } from "./models.js";
+import { T5ForConditionalGeneration } from "./models.js";
+import { AutoProcessor } from "./processors.js";
+import { pipeline } from "./pipelines.js";
+import { env } from "./env.js";
+export { AutoTokenizer, BertTokenizer, DistilBertTokenizer, T5Tokenizer, GPT2Tokenizer, AutoModel, AutoModelForSeq2SeqLM, AutoModelForSequenceClassification, AutoModelForCausalLM, AutoModelForMaskedLM, AutoModelForQuestionAnswering, AutoModelForVision2Seq, AutoModelForImageClassification, T5ForConditionalGeneration, AutoProcessor, pipeline, env };

--- a/dist/types/utils.d.ts
+++ b/dist/types/utils.d.ts
@@ -1,0 +1,39 @@
+export class Callable extends Function {
+    constructor();
+    _call(...args: any[]): void;
+}
+export function getModelFile(modelPath: any, fileName: any, progressCallback?: any): Promise<Uint8Array>;
+export function dispatchCallback(progressCallback: any, data: any): void;
+export function fetchJSON(modelPath: any, fileName: any, progressCallback?: any): Promise<any>;
+export function pathJoin(...parts: any[]): string;
+export function reverseDictionary(data: any): any;
+export function indexOfMax(arr: any): number;
+export function softmax(arr: any): any;
+export function log_softmax(arr: any): any;
+export function escapeRegExp(string: any): any;
+export function getTopItems(items: any, top_k?: number): any;
+export function dot(arr1: any, arr2: any): any;
+export function cos_sim(arr1: any, arr2: any): number;
+export function magnitude(arr: any): number;
+export function getFile(url: any): Promise<Response | FileResponse>;
+export function isIntegralNumber(x: any): boolean;
+export function isString(text: any): boolean;
+declare class FileResponse {
+    /**
+     * @param {string} filePath
+     */
+    constructor(filePath: string);
+    filePath: string;
+    headers: {};
+    exists: boolean;
+    status: number;
+    statusText: string;
+    body: ReadableStream<any>;
+    updateContentType(): void;
+    clone(): FileResponse;
+    arrayBuffer(): Promise<ArrayBufferLike>;
+    blob(): Promise<Blob>;
+    text(): Promise<string>;
+    json(): Promise<any>;
+}
+export {};

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "checkJs": true
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "@xenova/transformers",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@xenova/transformers",
-      "version": "1.2.4",
+      "version": "1.2.5",
       "license": "MIT",
       "dependencies": {
         "jimp": "^0.22.7",
-        "onnxruntime-web": "^1.14.0"
+        "onnxruntime-web": "^1.14.0",
+        "typescript": "^5.0.2"
       },
       "devDependencies": {
         "copy-webpack-plugin": "^11.0.0",
@@ -4103,6 +4104,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typescript": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.2.tgz",
+      "integrity": "sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -7781,6 +7794,11 @@
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
       }
+    },
+    "typescript": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.2.tgz",
+      "integrity": "sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw=="
     },
     "unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "build": "webpack",
+    "typegen": "tsc src/*.js --outDir dist/types --allowJs --declaration --emitDeclarationOnly",
     "dev": "webpack serve --no-client-overlay",
     "test": "node tests/index.js"
   },
@@ -29,7 +30,8 @@
   "homepage": "https://github.com/xenova/transformers.js#readme",
   "dependencies": {
     "jimp": "^0.22.7",
-    "onnxruntime-web": "^1.14.0"
+    "onnxruntime-web": "^1.14.0",
+    "typescript": "^5.0.2"
   },
   "devDependencies": {
     "copy-webpack-plugin": "^11.0.0",

--- a/src/tensor_utils.js
+++ b/src/tensor_utils.js
@@ -26,6 +26,11 @@ class Tensor extends ONNX.Tensor {
 
     }
 
+    /**
+     * 
+     * @param {number} index 
+     * @returns 
+     */
     get(index) {
         const iterDims = this.dims.slice(1);
         if (iterDims.length > 0) {
@@ -46,6 +51,12 @@ class Tensor extends ONNX.Tensor {
         return -1;
     }
 
+    /**
+     * @param {number} index 
+     * @param {number} iterSize 
+     * @param {number} iterDims 
+     * @returns {this}
+     */
     _subarray(index, iterSize, iterDims) {
         let data = this.data.subarray(index * iterSize, (index + 1) * iterSize);
         return new Tensor(this.type, data, iterDims);

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,6 +4,9 @@ const fs = require('fs');
 const { env } = require('./env.js');
 
 class FileResponse {
+    /**
+     * @param {string} filePath 
+     */
     constructor(filePath) {
         this.filePath = filePath;
         this.headers = {};


### PR DESCRIPTION
Fixes https://github.com/xenova/transformers.js/issues/25

This is a basic type setup, which enables type-checking/Intellisense aswell:

![image](https://user-images.githubusercontent.com/5236548/226113810-6eecb1bf-46fd-4e67-9f40-23ba3c149a82.png)

I just added two example JSDoc comments, to display how it works.

Since @chelouche9 asked for it, I would like to assign you to work out more types. Are you capable of doing so?

Whenever you have added more types, you can run:

`npm run typegen`

And commit both the JSDoc comments and the `dist/types` changes, so we have synchronized types.