### PR TITLE
Smart execution providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ env.remoteModels = false;
 
 // Set parent path of .wasm files. Defaults to use a CDN.
 env.onnx.wasm.wasmPaths = '/path/to/files/';
+
+#### Node.js
+
+This project uses `onnxruntime-web` as default backend. However if you add the `onnxruntime-node` dependency it will preferred over the web backend. `onnxruntime-node` is nearly 5X faster than WASM executor provider probably due to [this issue](https://github.com/microsoft/onnxruntime/issues/10311).
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ env.onnx.wasm.wasmPaths = '/path/to/files/';
 
 #### Node.js
 
-This project uses `onnxruntime-web` as default backend. However if you add the `onnxruntime-node` dependency in your project it will preferred over the web backend. `onnxruntime-node` is nearly 5X faster than WASM executor provider probably due to [this issue](https://github.com/microsoft/onnxruntime/issues/10311).
+This project uses `onnxruntime-web` as default backend. However if you add the `onnxruntime-node` dependancy in your project it will preferred over the web backend. `onnxruntime-node` is nearly 5X faster than WASM executor provider probably due to [this issue](https://github.com/microsoft/onnxruntime/issues/10311).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ env.onnx.wasm.wasmPaths = '/path/to/files/';
 
 #### Node.js
 
-This project uses `onnxruntime-web` as default backend. However if you add the `onnxruntime-node` dependency it will preferred over the web backend. `onnxruntime-node` is nearly 5X faster than WASM executor provider probably due to [this issue](https://github.com/microsoft/onnxruntime/issues/10311).
+This project uses `onnxruntime-web` as default backend. However if you add the `onnxruntime-node` dependency in your project it will preferred over the web backend. `onnxruntime-node` is nearly 5X faster than WASM executor provider probably due to [this issue](https://github.com/microsoft/onnxruntime/issues/10311).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -93,11 +93,11 @@ env.remoteModels = false;
 
 // Set parent path of .wasm files. Defaults to use a CDN.
 env.onnx.wasm.wasmPaths = '/path/to/files/';
+```
 
 #### Node.js
 
 This project uses `onnxruntime-web` as default backend. However if you add the `onnxruntime-node` dependency it will preferred over the web backend. `onnxruntime-node` is nearly 5X faster than WASM executor provider probably due to [this issue](https://github.com/microsoft/onnxruntime/issues/10311).
-```
 
 ## Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xenova/transformers",
-  "version": "1.2.4",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@xenova/transformers",
-      "version": "1.2.4",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "jimp": "^0.22.7",
@@ -17,6 +17,9 @@
         "webpack": "^5.76.0",
         "webpack-cli": "^5.0.1",
         "webpack-dev-server": "^4.11.1"
+      },
+      "peerDependencies": {
+        "onnxruntime-node": "^1.14.0"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -2983,6 +2986,20 @@
       "version": "1.14.0",
       "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.14.0.tgz",
       "integrity": "sha512-3LJpegM2iMNRX2wUmtYfeX/ytfOzNwAWKSq1HbRrKc9+uqG/FsEA0bbKZl1btQeZaXhC26l44NWpNUeXPII7Ew=="
+    },
+    "node_modules/onnxruntime-node": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.14.0.tgz",
+      "integrity": "sha512-5ba7TWomIV/9b6NH/1x/8QEeowsb+jBEvFzU6z0T4mNsFwdPqXeFUM7uxC6QeSRkEbWu3qEB0VMjrvzN/0S9+w==",
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "peer": true,
+      "dependencies": {
+        "onnxruntime-common": "~1.14.0"
+      }
     },
     "node_modules/onnxruntime-web": {
       "version": "1.14.0",
@@ -6966,6 +6983,15 @@
       "version": "1.14.0",
       "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.14.0.tgz",
       "integrity": "sha512-3LJpegM2iMNRX2wUmtYfeX/ytfOzNwAWKSq1HbRrKc9+uqG/FsEA0bbKZl1btQeZaXhC26l44NWpNUeXPII7Ew=="
+    },
+    "onnxruntime-node": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.14.0.tgz",
+      "integrity": "sha512-5ba7TWomIV/9b6NH/1x/8QEeowsb+jBEvFzU6z0T4mNsFwdPqXeFUM7uxC6QeSRkEbWu3qEB0VMjrvzN/0S9+w==",
+      "peer": true,
+      "requires": {
+        "onnxruntime-common": "~1.14.0"
+      }
     },
     "onnxruntime-web": {
       "version": "1.14.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,9 @@
     "webpack-cli": "^5.0.1",
     "webpack-dev-server": "^4.11.1"
   },
+  "peerDependencies": {
+    "onnxruntime-node": "^1.14.0"
+  },
   "files": [
     "src",
     "dist",

--- a/src/env.js
+++ b/src/env.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const onnx_env = require('onnxruntime-web').env;
+const { env: onnx_env } = require('./tensor_utils').ONNX;
 
 // check if various APIs are available (depends on environment)
 const CACHE_AVAILABLE = typeof self !== 'undefined' && 'caches' in self;

--- a/src/models.js
+++ b/src/models.js
@@ -29,9 +29,15 @@ const { InferenceSession, Tensor: ONNXTensor }  = ONNX;
 
 async function constructSession(modelPath, fileName, progressCallback = null) {
     let buffer = await getModelFile(modelPath, fileName, progressCallback);
-    let session = await InferenceSession.create(buffer, { executionProviders });
-
-    return session
+    try {
+        return await InferenceSession.create(buffer, { 
+            executionProviders 
+        });
+    } catch (err) {
+        return await InferenceSession.create(buffer, { 
+            executionProviders: ['wasm'] 
+        });
+    }
 }
 
 async function sessionRun(session, inputs) {

--- a/src/models.js
+++ b/src/models.js
@@ -21,22 +21,15 @@ const {
     WhisperTimeStampLogitsProcessor
 } = require("./generation.js");
 
-const { Tensor } = require('./tensor_utils.js')
-const ONNX = require('onnxruntime-web');
-
-const InferenceSession = ONNX.InferenceSession
-const ONNXTensor = ONNX.Tensor
+const { Tensor, ONNX, executionProviders } = require('./tensor_utils');
+const { InferenceSession, Tensor: ONNXTensor }  = ONNX;
 
 //////////////////////////////////////////////////
 // Helper functions
 
 async function constructSession(modelPath, fileName, progressCallback = null) {
     let buffer = await getModelFile(modelPath, fileName, progressCallback);
-
-    let session = await InferenceSession.create(buffer, {
-        // executionProviders: ["webgl"]
-        executionProviders: ["wasm"]
-    });
+    let session = await InferenceSession.create(buffer, { executionProviders });
 
     return session
 }

--- a/src/tensor_utils.js
+++ b/src/tensor_utils.js
@@ -6,7 +6,7 @@ try {
     executionProviders = [ 'cuda', 'cpu' ];
 } catch (err) {
     ONNX = require('onnxruntime-web');
-    if (typeof window === 'undefined') {
+    if(typeof process === 'object') {
         // https://github.com/microsoft/onnxruntime/issues/10311
         ONNX.env.wasm.numThreads = 1;
         executionProviders = [ 'cpu', 'wasm' ];

--- a/src/tensor_utils.js
+++ b/src/tensor_utils.js
@@ -1,4 +1,17 @@
-const ONNX = require('onnxruntime-web');
+let ONNX;
+let executionProviders = [ 'webgl', 'wasm' ];
+
+try {
+    ONNX = require('onnxruntime-node');
+    executionProviders = [ 'cuda', 'cpu' ];
+} catch (err) {
+    ONNX = require('onnxruntime-web');
+    if (typeof window === 'undefined') {
+        // https://github.com/microsoft/onnxruntime/issues/10311
+        ONNX.env.wasm.numThreads = 1;
+        executionProviders = [ 'cpu', 'wasm' ];
+    }
+}
 
 class Tensor extends ONNX.Tensor {
     constructor(...args) {
@@ -116,6 +129,8 @@ function cat(tensors) {
 }
 
 module.exports = {
+    ONNX,
+    executionProviders,
     Tensor,
     transpose,
     cat


### PR DESCRIPTION
 - closes #30 

The purpose of this PR is:
 - Best effort to use the gpu over cpu if not fallbacks to wasm
 - Use `onnxruntime-node` in case is installed as dep in any node app using transformers.js (5x faster than WASM). If not installed it will falback to WASM provider.
 - Adds the hack for [this issue](https://github.com/microsoft/onnxruntime/issues/10311) setting `numThreads` to one 
 - Use onnx executorProviders fallback chain to improve faster inference in browser if the model supports it.
 - Wraps multiple `onnxruntime-web`  requirement dependancy  under one file