### PR TITLE
added DIRNAME_AVAILABLE check in env for electron

### DIFF
--- a/src/env.js
+++ b/src/env.js
@@ -5,7 +5,7 @@ const { env: onnx_env } = require('./backends/onnx.js').ONNX;
 
 // check if various APIs are available (depends on environment)
 const CACHE_AVAILABLE = typeof self !== 'undefined' && 'caches' in self;
-const FS_AVAILABLE = !isEmpty(fs); // check if file system is available
+const FS_AVAILABLE = !isEmpty(fs) && typeof fs.existsSync === 'function'; // check if file system is available
 const PATH_AVAILABLE = !isEmpty(path); // check if path is available
 
 const RUNNING_LOCALLY = FS_AVAILABLE && PATH_AVAILABLE;


### PR DESCRIPTION
Hello, thanks for a great package! In electron on the web process `const fs = require('fs');` returns an object:
```
{ default: { /** empty */ } }
```
so it exists but cannot be used. I added another check:
```
const DIRNAME_AVAILABLE = typeof __dirname === 'string'
```

I could also test for some functions used like [`fs. existsSync()`](https://github.com/xenova/transformers.js/blob/fa0eb38c4966272480a62d5b090e052b3d86bbcd/src/utils.js#L12) if you'd prefer to do that over checking for `__dirname`. Let me know!