### PR TITLE
Add GitHub workflow to publish to npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,18 @@
+name: Publish
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Hello! 👋

This does require the addition of an NPM_TOKEN secret in the repo!

This PR would...
- Make it so that when you create a new GitHub release, it automagically builds and publishes the npm package to https://www.npmjs.com/
- **NOT** trigger on every single push to main
- **NOT** change anything about the current workflow
- Still allow manual publishing via your regular `npm publish` on your PC
- Allow a manual `workflow_dispatch` event from the GitHub web UI to trigger the publishing too (nice for testing or hotfixes)

Inspired by https://github.com/jcbhmr/transformers.js/pull/12