### PR TITLE
Add devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/javascript-node",
+  "features": {
+    "ghcr.io/devcontainers/features/python": {}
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,5 +2,10 @@
   "image": "mcr.microsoft.com/devcontainers/javascript-node",
   "features": {
     "ghcr.io/devcontainers/features/python": {}
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": ["esbenp.prettier-vscode", "ms-python.python"]
+    }
   }
 }


### PR DESCRIPTION
This PR would...

- Add a GitHub Codespaces configuration to this repo that...
- Uses the Node.js image
- Includes Python as an addon
- Has a VS Code Prettier formatted extension
- Has a Python VS Code extension
- [Also works with plain VS Code with the "Dev Containers" extension installed](https://code.visualstudio.com/docs/devcontainers/containers)

If you don't want to add _another_ config file to your repo, that's OK 😊 I understand.