### PR TITLE
Define ReadableStream from node:stream/web if it doesn't exist

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 
 const { env } = require('./env.js');
 
-if (global.ReadableStream  === undefined && typeof process !== 'undefined') {
+if (global.ReadableStream === undefined && typeof process !== 'undefined') {
     try {
         global.ReadableStream  = require('node:stream/web').ReadableStream; // ReadableStream is not a global with Node 16
     } catch(err) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,6 +3,14 @@ const fs = require('fs');
 
 const { env } = require('./env.js');
 
+if (global.ReadableStream  === undefined && typeof process !== 'undefined') {
+    try {
+        global.ReadableStream  = require('node:stream/web').ReadableStream; // ReadableStream is not a global with Node 16
+    } catch(err) {
+        console.warn("ReadableStream not defined and unable to import from node:stream/web");
+    }
+}
+
 class FileResponse {
     /**
      * Creates a new `FileResponse` object.


### PR DESCRIPTION
`ReadableStream` is not defined as a global under Node 16 (this causes an error within the FileResponse constructor), this pulls the class in from `node:stream/web`.