### PR TITLE
Fix tensor normalization in EmbeddingsPipeline

### DIFF
--- a/src/pipelines.js
+++ b/src/pipelines.js
@@ -628,7 +628,7 @@ class EmbeddingsPipeline extends Pipeline {
      */
     _normalize(tensor) {
         for (let batch of tensor) {
-            let norm = Math.sqrt(batch.data.reduce((a, b) => a + b * b))
+            let norm = Math.sqrt(batch.data.reduce((a, b) => a + b * b, 0))
 
             for (let i = 0; i < batch.data.length; ++i) {
                 batch.data[i] /= norm;


### PR DESCRIPTION
I was directly using the quantized all-MiniLM-L6-v2 onnx model to precompute some embeddings from Python, and I noticed some slight differences between those embeddings and the ones transformers.js generated. I found that the vector norm calculation wasn't squaring the first value of the vector: ```let norm = Math.sqrt(batch.data.reduce((a, b) => a + b * b))```.

Adding an initial value of 0 to the ```reduce``` fixes this. I've verified that this fixed normalization calculation results in embeddings equal to the ones generated directly from the onnx model!
