### PR TITLE
[Whisper] Implement/use getMelFilters

### DIFF
--- a/src/processors.js
+++ b/src/processors.js
@@ -38,6 +38,7 @@ import {
 import { Tensor, transpose, cat, interpolate } from './utils/tensor.js';
 
 import { CustomImage } from './utils/image.js';
+import { getMelFilters } from './utils/audio.js';
 
 
 /**
@@ -1017,6 +1018,14 @@ export class WhisperFeatureExtractor extends FeatureExtractor {
     }
 
     /**
+     * Prefer given `mel_filters` from preprocessor_config.json, or calculate them if they don't exist.
+     */
+    get melFilters() {
+        const { sampling_rate, n_fft, feature_size, mel_filters } = this.config;
+        return mel_filters ?? getMelFilters(sampling_rate, n_fft, feature_size);
+    }
+    
+    /**
      * Computes the log-Mel spectrogram of the provided audio waveform.
      * @param {Float32Array} waveform The audio waveform to process.
      * @returns {{data: Float32Array, dims: number[]}} An object containing the log-Mel spectrogram data as a Float32Array and its dimensions as an array of numbers.
@@ -1050,7 +1059,7 @@ export class WhisperFeatureExtractor extends FeatureExtractor {
             }
         }
 
-        const mel_filters = this.config.mel_filters
+        const mel_filters = this.melFilters;
         const num_mel_filters = mel_filters.length;
 
         const mel_spec = new Float32Array(num_mel_filters * d1);

--- a/src/utils/maths.js
+++ b/src/utils/maths.js
@@ -269,6 +269,28 @@ export function max(arr) {
     return [max, indexOfMax];
 }
 
+/**
+ * Code adapted from https://github.com/numpy/numpy/blob/25908cacd19915bf3ddd659c28be28a41bd97a54/numpy/fft/helper.py#L173-L221
+ * Original Python doc: Original Python doc: https://numpy.org/doc/stable/reference/generated/numpy.fft.rfftfreq.html
+ * @example
+ * rfftfreq(400, 1 / 16000) // (201) [0, 40, 80, 120, 160, 200, ..., 8000]
+ * @param {number} n Window length
+ * @param {number} [d = 1.0] Sample spacing (inverse of the sampling rate). Defaults to 1.
+ * @throws {TypeError}
+ * @returns {number[]} Array of length `Math.floor(n / 2) + 1;` containing the sample frequencies.
+ */
+ export function rfftfreq(n, d = 1.0) {
+    if (!Number.isInteger(n)) {
+        throw new TypeError(`n should be an integer, but ${n} given.`);
+    }
+    const val = 1.0 / (n * d);
+    const len = Math.floor(n / 2) + 1;
+    const results = new Array(len);
+    for (let i = 0; i < len; i++) {
+      results[i] = i * val;
+    }
+    return results;
+}
 
 /**
  * FFT class provides functionality for performing Fast Fourier Transform on arrays


### PR DESCRIPTION
Attempting to fix https://github.com/xenova/transformers.js/issues/107

Testing:

```js
url = "https://huggingface.co/Xenova/whisper-tiny.en/raw/main/preprocessor_config.json";
res = await fetch(url);
config = await res.json();
original_mel_filters = config.mel_filters;
calculated_mel_filters = getMelFilters(config.sampling_rate, config.n_fft, config.feature_size);
differences = [];
for (var i=0; i<80; i++) {
  for (var j=0; j<201; j++) {
    const expected = original_mel_filters[i][j];
    const calculated = calculated_mel_filters[i][j];
    if (expected !== calculated) {
        const diff = Math.abs(expected - calculated);
        differences.push({i, j, expected, calculated, diff});
    }
  }
}
console.table(differences);
```

There are differences, but they are all minuscule:

![image](https://github.com/xenova/transformers.js/assets/5236548/26655cce-b164-4607-bf0a-b8a061c793a8)

However, based on real transcribing, these differences do matter quite a lot... so this is a draft right now, until we figure out how to fine-tune the calculation to be exactly like the Python ones.