### PR TITLE
Do not use spread operator to concatenate large arrays (Closes #153)

### DIFF
--- a/src/utils/core.js
+++ b/src/utils/core.js
@@ -152,3 +152,13 @@ export function pop(obj, key, defaultValue = undefined) {
     }
     return defaultValue;
 }
+
+/**
+ * Efficiently merge arrays, creating a new copy.
+ * Adapted from https://stackoverflow.com/a/6768642/13989043
+ * @param  {...any} arrs Arrays to merge.
+ * @returns The merged array.
+ */
+export function mergeArrays(...arrs) {
+    return Array.prototype.concat.apply([], arrs);
+}

--- a/tests/tokenizers.test.js
+++ b/tests/tokenizers.test.js
@@ -33,3 +33,13 @@ describe('Tokenizers', () => {
         });
     }
 });
+
+describe('Edge cases', () => {
+    it('should not crash when encoding a very long string', async () => {
+        let tokenizer = await AutoTokenizer.from_pretrained('t5-small');
+
+        let text = String.prototype.repeat.call('Hello world! ', 50000);
+        let encoded = await tokenizer(text);
+        expect(encoded.input_ids.data.length).toBeGreaterThan(100000);
+    });
+});


### PR DESCRIPTION
Fixes "Maximum call stack size exceeded" which is caused by using the spread operator to concatenate large arrays.