### PR TITLE
Add `RobertaForTokenClassification` and an example checkpoint on Hub

### DIFF
--- a/scripts/supported_models.py
+++ b/scripts/supported_models.py
@@ -153,6 +153,7 @@ SUPPORTED_MODELS = {
 
         'sentence-transformers/all-distilroberta-v1',
         'sentence-transformers/all-roberta-large-v1',
+        'julien-c/EsperBERTo-small-pos',
     ],
     'sam': [
         'facebook/sam-vit-base',

--- a/src/models.js
+++ b/src/models.js
@@ -1676,6 +1676,22 @@ export class RobertaForSequenceClassification extends RobertaPreTrainedModel {
 }
 
 /**
+ * RobertaForTokenClassification class for performing token classification on Roberta models.
+ * @extends RobertaPreTrainedModel
+ */
+export class RobertaForTokenClassification extends RobertaPreTrainedModel {
+    /**
+     * Calls the model on new inputs.
+     *
+     * @param {Object} model_inputs The inputs to the model.
+     * @returns {Promise<TokenClassifierOutput>} An object containing the model's output logits for token classification.
+     */
+    async _call(model_inputs) {
+        return new TokenClassifierOutput(await super._call(model_inputs));
+    }
+}
+
+/**
  * RobertaForQuestionAnswering class for performing question answering on Roberta models.
  * @extends RobertaPreTrainedModel
  */
@@ -2514,6 +2530,7 @@ const MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING_NAMES = new Map([
 const MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING_NAMES = new Map([
     ['bert', BertForTokenClassification],
     ['distilbert', DistilBertForTokenClassification],
+    ['roberta', RobertaForTokenClassification],
 ]);
 
 const MODEL_FOR_SEQ_2_SEQ_MAPPING_NAMES = new Map([


### PR DESCRIPTION
## Use case: perform [parts-of-speech tagging](https://en.wikipedia.org/wiki/Part-of-speech_tagging) in Esperanto

Code to test:

```js
const classifyTokens = await pipeline("token-classification", "julien-c/EsperBERTo-small-pos");
await classifyTokens("Mi estas viro kej estas tago varma.");
```

Output:

```js
[
  {
    entity: 'PRON',
    score: 0.9999696612358093,
    index: 1,
    word: 'Mi',
    start: null,
    end: null
  },
  {
    entity: 'VERB',
    score: 0.9770894050598145,
    index: 2,
    word: ' estas',
    start: null,
    end: null
  },
  {
    entity: 'ADJ',
    score: 0.7278493642807007,
    index: 3,
    word: ' viro',
    start: null,
    end: null
  },
  {
    entity: 'VERB',
    score: 0.9786341786384583,
    index: 6,
    word: ' estas',
    start: null,
    end: null
  },
  {
    entity: 'NOUN',
    score: 0.8334921002388,
    index: 7,
    word: ' tago',
    start: null,
    end: null
  },
  {
    entity: 'ADJ',
    score: 0.9996510148048401,
    index: 8,
    word: ' varma',
    start: null,
    end: null
  }
]
```

Consistent with server-side computation as seen on https://huggingface.co/julien-c/EsperBERTo-small-pos

<img width="895" alt="image" src="https://github.com/xenova/transformers.js/assets/326577/01ff963a-5e32-4b3f-b3f1-e24a85c01b13">
