### PR TITLE
Fixed an issue with an error during pipeline execution

### DIFF
--- a/src/utils/hub.js
+++ b/src/utils/hub.js
@@ -459,7 +459,7 @@ export async function getModelFile(path_or_repo_id, filename, fatal = true, opti
         }
 
 
-        if (cache && response instanceof Response && response.status === 200) {
+        if (cache && response.status === 200) {
             // only clone if cache available, and response is valid
             responseToCache = response.clone();
         }


### PR DESCRIPTION
The error I am getting is the following - 

```
ReferenceError: Response is not defined
 at getModelFile /node_modules/@xenova/transformers/src/utils/hub.js:462:42
```

The environment I am using is NodeJS v16.15.0 with TypeScript with the default CommonJS configuration. 

This Commit fixes the issue.