### PR TITLE
[Llama + LLama2] Add model support (Closes #231)

### DIFF
--- a/src/models.js
+++ b/src/models.js
@@ -1694,13 +1694,13 @@ export class MT5ForConditionalGeneration extends MT5PreTrainedModel {
     }
 
     /**
-   * Generates the start beams for the given input tokens and output sequence length.
-   *
-   * @param {any[]} inputs The input sequence.
-   * @param {number} numOutputTokens The desired length of the output sequence.
-   * @param {...*} args Additional arguments to pass to the `seq2seqStartBeams` function.
-   * @returns {any[]} An array of `Beam` objects representing the start beams.
-   */
+     * Generates the start beams for the given input tokens and output sequence length.
+     *
+     * @param {any[]} inputs The input sequence.
+     * @param {number} numOutputTokens The desired length of the output sequence.
+     * @param {...*} args Additional arguments to pass to the `seq2seqStartBeams` function.
+     * @returns {any[]} An array of `Beam` objects representing the start beams.
+     */
     getStartBeams(inputs, numOutputTokens, ...args) {
         return seq2seqStartBeams(this, inputs, numOutputTokens);
     }

--- a/src/models.js
+++ b/src/models.js
@@ -1718,16 +1718,16 @@ export class MT5ForConditionalGeneration extends MT5PreTrainedModel {
      * Updates the given beam with the new predicted token.
      * @param {any} beam The beam to update.
      * @param {number} newTokenId The index of the predicted token.
-    */
+     */
     updateBeam(beam, newTokenId) {
         beam.output_token_ids = [...beam.output_token_ids, newTokenId];
     }
 
     /**
-    * Runs the forward pass of the model on the given inputs.
-    * @param {any} model_inputs The model inputs.
-    * @returns {Promise<any>} A Promise that resolves to the model outputs.
-    */
+     * Runs the forward pass of the model on the given inputs.
+     * @param {any} model_inputs The model inputs.
+     * @returns {Promise<any>} A Promise that resolves to the model outputs.
+     */
     async forward(model_inputs) {
         return await seq2seqForward(this, model_inputs);
     }

--- a/src/models.js
+++ b/src/models.js
@@ -2742,6 +2742,94 @@ export class CodeGenForCausalLM extends CodeGenPreTrainedModel {
 }
 //////////////////////////////////////////////////
 
+
+//////////////////////////////////////////////////
+// LLama models
+
+/**
+ * The bare LLama Model outputting raw hidden-states without any specific head on top.
+ */
+export class LlamaPreTrainedModel extends PreTrainedModel {
+    /**
+     * Creates a new instance of the `LlamaPreTrainedModel` class.
+    * @param {Object} config The model configuration object.
+    * @param {Object} session The ONNX session object.
+    */
+    constructor(config, session) {
+        super(config, session);
+
+        // config doesn't contain pad_token_id, so we assume it is the eos_token_id
+        this.config.pad_token_id = this.config.eos_token_id
+
+        this.num_heads = this.config.num_attention_heads
+        this.num_layers = this.config.num_hidden_layers
+        this.dim_kv = this.config.hidden_size / this.num_heads;
+    }
+}
+/**
+ * The bare LLaMA Model outputting raw hidden-states without any specific head on top.
+ */
+export class LlamaModel extends LlamaPreTrainedModel {
+    /**
+     * Throws an error indicating that the current model class is not compatible with `.generate()`,
+     * as it doesn't have a language model head.
+     * 
+     * @throws {Error} The current model class is not compatible with `.generate()`
+     * 
+     * @param  {...any} args Arguments passed to the generate function
+     * @returns {Promise<any>}
+     */
+    async generate(...args) {
+        throw Error(
+            "The current model class (LlamaModel) is not compatible with `.generate()`, as it doesn't have a language model head. Please use one of the following classes instead: {'LlamaForCausalLM'}"
+        )
+    }
+}
+
+export class LlamaForCausalLM extends LlamaPreTrainedModel {
+
+    /**
+     * Initializes and returns the beam for text generation task
+     * @param {Tensor} inputTokenIds The input token ids.
+     * @param {number} numOutputTokens The number of tokens to be generated.
+     * @param {Tensor} inputs_attention_mask Optional input attention mask.
+     * @returns {any} A Beam object representing the initialized beam.
+     */
+    getStartBeams(inputTokenIds, numOutputTokens, inputs_attention_mask) {
+        return decoderStartBeams(this, inputTokenIds, numOutputTokens, inputs_attention_mask)
+    }
+
+    /**
+     * Runs a single step of the beam search generation algorithm.
+     * @param {any} beam The current beam being generated.
+     * @returns {Promise<any>} The updated beam after a single generation step.
+     */
+    async runBeam(beam) {
+        return await decoderRunBeam(this, beam);
+    }
+
+    /**
+     * Updates the given beam with the new generated token id.
+     * @param {any} beam The Beam object representing the beam.
+     * @param {number} newTokenId The new generated token id to be added to the beam.
+     */
+    updateBeam(beam, newTokenId) {
+        return decoderUpdatebeam(beam, newTokenId);
+    }
+
+    /**
+     * Forward pass for the model.
+     * @param {Object} model_inputs The inputs for the model.
+     * @returns {Promise<any>} The output tensor of the model.
+     */
+    async forward(model_inputs) {
+        return await decoderForward(this, model_inputs);
+    }
+
+}
+//////////////////////////////////////////////////
+
+
 //////////////////////////////////////////////////
 export class ViTPreTrainedModel extends PreTrainedModel { }
 export class ViTForImageClassification extends ViTPreTrainedModel {
@@ -3116,6 +3204,7 @@ const MODEL_MAPPING_NAMES_DECODER_ONLY = new Map([
     ['gpt_bigcode', GPTBigCodeModel],
     ['gpt_neo', GPTNeoModel],
     ['codegen', CodeGenModel],
+    ['llama', LlamaModel],
 ]);
 
 const MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING_NAMES = new Map([
@@ -3152,6 +3241,7 @@ const MODEL_WITH_LM_HEAD_MAPPING_NAMES = new Map([
     ['gpt_bigcode', GPTBigCodeForCausalLM],
     ['gpt_neo', GPTNeoForCausalLM],
     ['codegen', CodeGenForCausalLM],
+    ['llama', LlamaForCausalLM],
 ]);
 
 const MODEL_FOR_MASKED_LM_MAPPING_NAMES = new Map([


### PR DESCRIPTION
This PR adds support for running Llama/Llama2 models in Transformers.js. It's worth noting, however, that due to various browser/WASM/ONNX limitations, I won't be releasing converted checkpoints for the set of >7B parameter models released by Meta. Instead, I'll be testing correctness with Andrej Karpathy's [TinyLlama models](https://huggingface.co/karpathy/tinyllamas) (see his [llama2.c repo](https://github.com/karpathy/llama2.c) for more information).

## Usage
```js
import { pipeline } from '@xenova/transformers';

const generator = await pipeline("text-generation", 'Xenova/llama2.c-stories42M');

const prompt = `Alice was so tired when she got back home so she went`
const output = await generator(prompt, {
    max_new_tokens: 25,
})
console.log(output[0]);
// { generated_text: 'Alice was so tired when she got back home so she went to bed. She was so tired. She had a dream. She was so happy. She was so excited to explore the' }

```

## Models:
- https://huggingface.co/Xenova/llama2.c-stories15M
- https://huggingface.co/Xenova/llama2.c-stories42M
- https://huggingface.co/Xenova/llama2.c-stories110M

## Tests:
- Running on an i9-9900k. 
- No fancy sampling... just greedy
- Prompt (from the [TinyStories](https://arxiv.org/pdf/2305.07759.pdf) paper): `Alice was so tired when she got back home so she went`

<details><summary>Code</summary>

```js
import { pipeline } from '@xenova/transformers';

const prompt = `Alice was so tired when she got back home so she went`

const models = [
    "Xenova/llama2.c-stories15M",
    "Xenova/llama2.c-stories42M",
    "Xenova/llama2.c-stories110M",
]

const quantizations = [false, true];

for (const model of models) {
    for (const quantized of quantizations) {
        const generator = await pipeline("text-generation", model, { quantized });

        const start = performance.now();
        const { generated_text } = (await generator(prompt, {
            max_new_tokens: 25,
        }))[0];
        const duration = performance.now() - start;
        console.log('='.repeat(80));
        console.log(`Test: ${model} ${quantized ? 'quantized' : 'unquantized'}`);
        console.log(`Duration: ${duration}`);
        console.log(`Continuation: ${generated_text}`);
        console.log('='.repeat(80));

        await generator.dispose();
    }
}

```
</details>


| Model | quantized? | tokens/sec (node; browser) | Continuation |
|--------|--------|--------|--------|
| 15M | no | 88.6; 77.4 | to the day that last. She was very long. Once, but she was a bitored. She washter |
| 15M | yes | 120.3; 67.4 | to the day that last. She was to the same. She was a little girl'd'darian. She was |
| 42M | no | 66.9; 47.8 | to bed. She was so happy. She had a big surprise. She had a big smile on her face. She had |
| 42M | yes | 100.0; 35.7| to bed. She was so tired. She had a dream. She was so happy. She was so excited to explore the | 
| 110M | no | 34.4; 21.1 | to her bed. She was so excited because she was going to the park with her mom. She was wearing her new | 
| 110M | yes | 63.9; 15.7 | to her bed. She was so excited to see her mommy. Mommy and she was so excited to see her | 

