### PR TITLE
Improve onnx conversion instructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,11 +149,23 @@ For a full list of available settings, check out the [API Reference](https://hug
 
 We recommend using our [conversion script](https://github.com/xenova/transformers.js/blob/main/scripts/convert.py) to convert your PyTorch, TensorFlow, or JAX models to ONNX in a single command. Behind the scenes, it uses [🤗 Optimum](https://huggingface.co/docs/optimum) to perform conversion and quantization of your model.
 
+Assuming you have Python 3 installed, create a virtual environment `onnxconversion` with all dependencies:
+
+```bash
+python -m venv onnxconversion
+source onnxconversion/bin/activate
+python -m pip install -r scripts/requirements.txt
+```
+
+Then use our script to convert the model:
+
 ```bash
 python -m scripts.convert --quantize --model_id <model_name_or_path>
 ```
+According to the 🤗 URL, `model_name_or_path` can be in the format `<user>/<model>` e.g. `intfloat/multilingual-e5-small` for https://huggingface.co/intfloat/multilingual-e5-small or for certain models just `<model>` e.g. `bert-base-uncased` for https://huggingface.co/bert-base-uncased.
 
 For example, convert and quantize [bert-base-uncased](https://huggingface.co/bert-base-uncased) using:
+
 ```bash
 python -m scripts.convert --quantize --model_id bert-base-uncased
 ```
@@ -169,7 +181,6 @@ bert-base-uncased/
     ├── model.onnx
     └── model_quantized.onnx
 ```
-
 
 ## Supported tasks/models
 

--- a/scripts/supported_models.py
+++ b/scripts/supported_models.py
@@ -59,6 +59,10 @@ SUPPORTED_MODELS = {
         'intfloat/e5-large',
         'intfloat/e5-large-v2',
         'intfloat/multilingual-e5-base',
+
+        'thenlper/gte-small',
+        'thenlper/gte-base',
+        'thenlper/gte-large',
     ],
     # TODO:
     # 'bloom':[

--- a/src/models.js
+++ b/src/models.js
@@ -446,10 +446,8 @@ async function encoderForward(self, model_inputs) {
     for (let key of self.session.inputNames) {
         encoderFeeds[key] = model_inputs[key];
     }
-    if (self.session.inputNames.includes('token_type_ids')) {
-        const token_type_ids = model_inputs.attention_mask.clone();
-        token_type_ids.data.fill(0n);
-        encoderFeeds.token_type_ids = token_type_ids
+    if (!encoderFeeds.token_type_ids && self.session.inputNames.includes('token_type_ids')) {
+        add_token_types(encoderFeeds);
     }
     return await sessionRun(self.session, encoderFeeds);
 }


### PR DESCRIPTION
- Creation and activation of venv onnxconversion
- Installation of requirements.txt
- Short explanation of huggingface URL model identifiers

I thought a short note on how to use the conversion script might be useful for non-Python users. I used venv (and not e.g. conda) as it's built-in.