### PR TITLE
Add problem type (Fixes #248)

### DIFF
--- a/scripts/supported_models.py
+++ b/scripts/supported_models.py
@@ -63,6 +63,8 @@ SUPPORTED_MODELS = {
         'thenlper/gte-small',
         'thenlper/gte-base',
         'thenlper/gte-large',
+
+        'unitary/toxic-bert',
     ],
     # TODO:
     # 'bloom':[

--- a/tests/pipelines.test.js
+++ b/tests/pipelines.test.js
@@ -18,8 +18,10 @@ describe('Pipelines', () => {
         // List all models which will be tested
         const models = [
             'distilbert-base-uncased-finetuned-sst-2-english',
+            'Xenova/toxic-bert',
         ];
 
+        // single_label_classification
         it(models[0], async () => {
             let classifier = await pipeline('text-classification', m(models[0]));
             let texts = [
@@ -82,6 +84,27 @@ describe('Pipelines', () => {
             await classifier.dispose();
 
         }, MAX_TEST_EXECUTION_TIME);
+
+        // multi_label_classification
+        it(models[1], async () => {
+            let classifier = await pipeline('text-classification', m(models[1]));
+            let texts = [
+                "I like you. I love you", // low scores
+                "I hate you." // high scores
+            ];
+
+            // single
+            {
+                let outputs = await classifier(texts);
+                let expected = [
+                    { label: 'toxic', score: 0.0007729064091108739 },
+                    { label: 'toxic', score: 0.9475088119506836 }
+                ]
+                compare(outputs, expected);
+            }
+        }, MAX_TEST_EXECUTION_TIME);
+
+
     });
 
     describe('Token classification', () => {


### PR DESCRIPTION
Adds support for different problem types (i.e., multi label classification) in the text classification pipeline.


### Python:
```python
from transformers import pipeline
classifier = pipeline('text-classification', 'unitary/toxic-bert')
classifier('I like you. I love you')
# [{'label': 'toxic', 'score': 0.0007729075732640922}]
```

### JavaScript
```javascript
import { pipeline } from '@xenova/transformers';
const classifier = await pipeline('text-classification', 'Xenova/toxic-bert', {quantized: false});
const output = await classifier('I like you. I love you');
// [{label: 'toxic', score: 0.0007729064091108739}]
```