### PR TITLE
Fix caching for LFS files from the Hugging Face Hub

### DIFF
--- a/examples/demo-site/src/worker.js
+++ b/examples/demo-site/src/worker.js
@@ -4,7 +4,8 @@
 // Needed to ensure the UI thread is not blocked when running  //
 /////////////////////////////////////////////////////////////////
 
-import { pipeline } from "@xenova/transformers";
+import { pipeline, env } from "@xenova/transformers";
+env.allowLocalModels = false;
 
 // Define task function mapping
 const TASK_FUNCTION_MAPPING = {


### PR DESCRIPTION
In rare cases, certain files from the Hub throw a strange error: `NetworkError: Cache.put() encountered a network error.` Investigating the network tab indicates the contradictory response: `ERR_FAILED 200`. This PR should handle this by creating a new `Response` object from the read buffer (instead of the response object to be re-read). This should also provide performance improvements.

Other notes:
- Doesn't affect previously cached files (those will still load correctly and don't need to be removed/redownloaded)
- Faster caching since we already have the body (should not result in duplication at all).