### PR TITLE
Make // @ts-ignore obsolete for _call overrides by respecting LSP

### DIFF
--- a/src/pipelines.js
+++ b/src/pipelines.js
@@ -308,7 +308,7 @@ export class TokenClassificationPipeline extends Pipeline {
  */
 
 /**
- * @typedef {Promise<QuestionAnsweringResult|QuestionAnsweringResult[]|undefined>} QuestionAnsweringReturnType
+ * @typedef {Promise<QuestionAnsweringResult|QuestionAnsweringResult[]>} QuestionAnsweringReturnType
  */
 
 /**
@@ -334,8 +334,8 @@ export class QuestionAnsweringPipeline extends Pipeline {
      * @param {string|string[]} context The context(s) where the answer(s) can be found.
      * @param {Object} options An optional object containing the following properties:
      * @param {number} [options.topk=1] The number of top answer predictions to be returned.
-     * @returns {QuestionAnsweringReturnType} A promise that resolves to an array or object containing the
-     * predicted answers and scores. Can also return undefined in case of `topk = 1`.
+     * @returns {QuestionAnsweringReturnType} A promise that resolves to an array or object
+     * containing the predicted answers and scores.
      */
     async _call(question, context = '', {
         topk = 1

--- a/src/pipelines.js
+++ b/src/pipelines.js
@@ -302,6 +302,16 @@ export class TokenClassificationPipeline extends Pipeline {
 }
 
 /**
+ * @typedef {object} QuestionAnsweringResult
+ * @property {string} answer - The answer.
+ * @property {number} score - The score.
+ */
+
+/**
+ * @typedef {Promise<QuestionAnsweringResult|QuestionAnsweringResult[]|undefined>} QuestionAnsweringReturnType
+ */
+
+/**
  * Question Answering pipeline using any `ModelForQuestionAnswering`.
  * 
  * **Example:** Run question answering with `Xenova/distilbert-base-uncased-distilled-squad`.
@@ -324,10 +334,10 @@ export class QuestionAnsweringPipeline extends Pipeline {
      * @param {string|string[]} context The context(s) where the answer(s) can be found.
      * @param {Object} options An optional object containing the following properties:
      * @param {number} [options.topk=1] The number of top answer predictions to be returned.
-     * @returns {Promise<any>} A promise that resolves to an array or object containing the predicted answers and scores.
+     * @returns {QuestionAnsweringReturnType} A promise that resolves to an array or object containing the
+     * predicted answers and scores. Can also return undefined in case of `topk = 1`.
      */
-    // @ts-ignore
-    async _call(question, context, {
+    async _call(question, context = '', {
         topk = 1
     } = {}) {
 
@@ -760,8 +770,7 @@ export class ZeroShotClassificationPipeline extends Pipeline {
      * candidate by doing a softmax of the entailment score vs. the contradiction score.
      * @return {Promise<Object|Object[]>} The prediction(s), as a map (or list of maps) from label to score.
      */
-    // @ts-ignore
-    async _call(texts, candidate_labels, {
+    async _call(texts, candidate_labels = [], {
         hypothesis_template = "This example is {}.",
         multi_label = false,
     } = {}) {
@@ -1602,8 +1611,7 @@ export class ZeroShotImageClassificationPipeline extends Pipeline {
      * @param {string} [options.hypothesis_template] The hypothesis template to use for zero-shot classification. Default: "This is a photo of {}".
      * @returns {Promise<any>} An array of classifications for each input image or a single classification object if only one input image is provided.
      */
-    // @ts-ignore
-    async _call(images, candidate_labels, {
+    async _call(images, candidate_labels = [], {
         hypothesis_template = "This is a photo of {}"
     } = {}) {
         let isBatched = Array.isArray(images);

--- a/src/pipelines.js
+++ b/src/pipelines.js
@@ -109,9 +109,10 @@ export class Pipeline extends Callable {
     /**
      * Executes the task associated with the pipeline.
      * @param {any} texts The input texts to be processed.
+     * @param {...any} unused Only used to fix Liskov Substitution Principle errors.
      * @returns {Promise<any>} A promise that resolves to an array containing the inputs and outputs of the task.
      */
-    async _call(texts) {
+    async _call(texts, ...unused) {
         // Run tokenization
         let model_inputs = this.tokenizer(texts, {
             padding: true,
@@ -337,7 +338,7 @@ export class QuestionAnsweringPipeline extends Pipeline {
      * @returns {QuestionAnsweringReturnType} A promise that resolves to an array or object
      * containing the predicted answers and scores.
      */
-    async _call(question, context = '', {
+    async _call(question, context, {
         topk = 1
     } = {}) {
 
@@ -770,7 +771,7 @@ export class ZeroShotClassificationPipeline extends Pipeline {
      * candidate by doing a softmax of the entailment score vs. the contradiction score.
      * @return {Promise<Object|Object[]>} The prediction(s), as a map (or list of maps) from label to score.
      */
-    async _call(texts, candidate_labels = [], {
+    async _call(texts, candidate_labels, {
         hypothesis_template = "This example is {}.",
         multi_label = false,
     } = {}) {
@@ -1611,7 +1612,7 @@ export class ZeroShotImageClassificationPipeline extends Pipeline {
      * @param {string} [options.hypothesis_template] The hypothesis template to use for zero-shot classification. Default: "This is a photo of {}".
      * @returns {Promise<any>} An array of classifications for each input image or a single classification object if only one input image is provided.
      */
-    async _call(images, candidate_labels = [], {
+    async _call(images, candidate_labels, {
         hypothesis_template = "This is a photo of {}"
     } = {}) {
         let isBatched = Array.isArray(images);


### PR DESCRIPTION
Fixes https://github.com/xenova/transformers.js/issues/275

Right now we violate the Liskov Substitution Principle:

> Simply put, the Liskov Substitution Principle (LSP) states that objects of a superclass should be replaceable with objects of its subclasses without breaking the application. In other words, what we want is to have the objects of our subclasses behaving the same way as the objects of our superclass.

Minified example:

```js
class Callable {
    /**
     * This method should be implemented in subclasses to provide the
     * functionality of the callable object.
     *
     * @param {any[]} args
     * @throws {Error} If the subclass does not implement the `_call` method.
     */
    _call(...args) {
        throw Error('Must implement _call method in subclass')
    }
}

class Pipeline extends Callable {
    /**
     * Executes the task associated with the pipeline.
     * @param {any} texts The input texts to be processed.
     * @returns {Promise<any>} A promise that resolves to an array containing the inputs and outputs of the task.
     */
    async _call(texts) {
        // ...
    }
}

class QuestionAnsweringPipeline extends Pipeline {
    /**
     * Executes the question answering task.
     * @param {string|string[]} question The question(s) to be answered.
     * @param {string|string[]} context The context(s) where the answer(s) can be found.
     * @param {Object} options An optional object containing the following properties:
     * @param {number} [options.topk=1] The number of top answer predictions to be returned.
     * @returns {Promise<any>} A promise that resolves to an array or object containing the predicted answers and scores.
     */
    async _call(question, context, {
        topk = 1
    } = {}) {
        // ...
    }
}

```

[TS Playground](https://www.typescriptlang.org/play?ts=4.6.2&filetype=js#code/MYGwhgzhAEDCYnAIxAU2gbwFDV9A9AFSE57SHQAqAFgJYwC2qALtQPYAm0E7AriFyTpaDAA5omAO2aoutSd15JQkCKhjM20UQCc2AN1od0rVKTwUAZr0nBmtNpIS1mAT2htL0U9GAJkaB5IAFaodgB05rgkZOTQAAKiYDpgDJhgkq4A2gC6AL7QyQDmEFFx8ax6AO4wGACiOno6BQCSXj4QSipQ0Bxs6tCSbMzQIuKoUiM+AAYA+n6I09BMrJyRsYT4UfP+ABThB8UQAJSYZXiVbFXQDU27AOQAsrwQI2MSqNLQO4jLLOxyBSdZTgKD3Y5RPJYKFYbowAAKtFEqBA8nQqAAHjJJBwYPBEGAUOhsGQiDEyBQ6hiwrwZBpqCZIABrQpQNjAWhgGRcKouajeBnaJEotHrCkJJIpNIYDKuAoyLEwGjCSSiWneTHMDRaITaPTAdRqDhiiwJHQsXg6SS1eF6Bj0VAAHllAD4CgBBPVse1qAVc6DmiBsED6AaaQoKZIpdzARzMMDyeRFAUqtVaiNcNi0tMwTwp7zMk3RLZkSCuWzfBYgXYKrWnEmxXD4fDQA5FqEwuHQACKvHU9kc7utVVQOiTiORqMk6Kxn1x0AnIunZ1JxDKlOpwFpYcFAEc+68HJHh6OkwWIEyi+VJalMK8x5IigAfe9J3IFff9o9UPcHgeSXYTm8HV0AyCAR3NY11wlZJbwwV9HxfZgHyKd9fDjTUf3QWNpE1QDTiqBlzXzMCIPw3wMmgXVLCzHErwoRJYOlAB5EIwmYAo2FEf8YCHDxuKPBAglCOx0OkBNJDPHwaMQK4z10LjR3sdQAC5oMYqVMEkXgGCEZpoCyLiePCTRRCZABeABGHIsMGHS9I8douIjcDRz1WRaDsI9tSo9BzWYS1pygjYzQtK0bTtB1nUyN1oE9BSfRMah-UDYNQx8yiozAdw2B0YT2LE+NE0ffNdA8uxZBciCYAyLgIFjQN6JLPAywrH5q0-Q9HAAGkKzVeobRtTJZczoEsyFoFGjA8nrc4mxbNtIWhLAgA)

Solution? We just need default values of the extra arguments (e.g. `context` for `QuestionAnsweringPipeline#call` to make the function signatures compatible. Should work like that with the other cases too... only task is: picking sensible default values

So now we can run it without context:

![image](https://github.com/xenova/transformers.js/assets/5236548/8660c665-7da5-4684-9bfb-97c192eaafc6)

However, I could also imagine this being a nice solution:

![image](https://github.com/xenova/transformers.js/assets/5236548/4b9d62bc-d7b7-4ee8-ae0c-75b116254f70)

Basically just `context = 'missing context'` default argument. Any thoughts / reflections?