### PR TITLE
Revert doc builder

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -11,7 +11,7 @@ jobs:
     uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@main
     with:
       repo_owner: xenova
-      commit_sha: ${{ github.sha }}
+      commit_sha: 7bfc590f793a6281b87e56cd8b0819fe58a12014
       package: transformers.js
       path_to_docs: transformers.js/docs/source
       pre_command: cd transformers.js && npm install && npm run docs-api

--- a/.github/workflows/pr-documentation.yml
+++ b/.github/workflows/pr-documentation.yml
@@ -12,7 +12,7 @@ jobs:
     uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@main
     with:
       repo_owner: xenova
-      commit_sha: ${{ github.sha }}
+      commit_sha: 7bfc590f793a6281b87e56cd8b0819fe58a12014
       pr_number: ${{ github.event.number }}
       package: transformers.js
       path_to_docs: transformers.js/docs/source


### PR DESCRIPTION
Recent changes to doc-builder broke transformers.js docs, so this PR temporarily reverts to a previous version of doc-builder which worked.