### PR TITLE
Add start and end char indexes to QnA pipeline

### DIFF
--- a/src/pipelines.js
+++ b/src/pipelines.js
@@ -378,10 +378,17 @@ export class QuestionAnsweringPipeline extends Pipeline {
                     skip_special_tokens: true,
                 });
 
-                // TODO add start and end?
-                // NOTE: HF returns character index
+                // Get start and end character indexes of answer within context
+                let startCharIndexOfContext = null
+                let endCharIndexOfContext = null
+                if (answer) {
+                    const textBeforeAnswer = this.tokenizer.decode([...ids].slice(sepIndex + 1, start))
+                    startCharIndexOfContext = textBeforeAnswer.length + 1
+                    endCharIndexOfContext = startCharIndexOfContext + answer.length
+                }
+
                 toReturn.push({
-                    answer, score
+                    answer, score, start: startCharIndexOfContext, end: endCharIndexOfContext
                 });
             }
         }


### PR DESCRIPTION
Summary of change: 
`QuestionAnsweringPipeline` returns the `start` and `end` character index values of the `answer` within `context`.

Reason for request:
- This allows the end-user to view where the answer is sourced from the context document. The python version of Transformers currently returns those indexes for the question-answering pipeline. 
- This feature was commented as a TODO by Xenova. 

Feature was discussed on this issue:
https://github.com/xenova/transformers.js/issues/312