### PR TITLE
Do not post-process `<` and `>` symbols generated from docs

### DIFF
--- a/docs/scripts/generate.js
+++ b/docs/scripts/generate.js
@@ -58,9 +58,6 @@ for (const moduleName of moduleNames) {
     // TODO: May need to extend this list
     output = output.replace(/\\([|_&*])/gm, '$1');
 
-    output = output.replaceAll('&lt;', '&amp;lt;');
-    output = output.replaceAll('&gt;', '&amp;gt;');
-
     output = output.replaceAll('new exports.', 'new ');
 
     let outputPath = path.resolve(outputDir, `${moduleName}.md`);

--- a/src/utils/image.js
+++ b/src/utils/image.js
@@ -98,7 +98,7 @@ export class RawImage {
      * **Example:** Read image from a URL.
      * ```javascript
      * let image = await RawImage.read('https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/football-match.jpg');
-     * // test {
+     * // RawImage {
      * //   "data": Uint8ClampedArray [ 25, 25, 25, 19, 19, 19, ... ],
      * //   "width": 800,
      * //   "height": 533,


### PR DESCRIPTION
Due to recent improvements to doc-builder, this post-processing isn't necessary anymore
cc @mishig25 