### PR TITLE
Upgrade typescript dependency version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "jest": "^29.5.0",
         "jest-environment-node": "^29.5.0",
         "jsdoc-to-markdown": "^8.0.0",
-        "typescript": "^5.0.2",
+        "typescript": "^5.2.2",
         "wavefile": "^11.0.0",
         "webpack": "^5.80.0",
         "webpack-cli": "^5.0.2",
@@ -7374,16 +7374,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.2.tgz",
-      "integrity": "sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=12.20"
+        "node": ">=14.17"
       }
     },
     "node_modules/typical": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "jest": "^29.5.0",
     "jest-environment-node": "^29.5.0",
     "jsdoc-to-markdown": "^8.0.0",
-    "typescript": "^5.0.2",
+    "typescript": "^5.2.2",
     "wavefile": "^11.0.0",
     "webpack": "^5.80.0",
     "webpack-cli": "^5.0.2",


### PR DESCRIPTION
Fix `typegen` incorrectly outputs `const` for non-readonly fields.

Closes #361
