### PR TITLE
Fix `text2text-generation` pipeline output inconsistency w/ python library

### DIFF
--- a/docs/source/pipelines.md
+++ b/docs/source/pipelines.md
@@ -131,13 +131,10 @@ let result = await poet('Write me a love poem about cheese.', {
     temperature: 0.9,
     repetition_penalty: 2.0,
     no_repeat_ngram_size: 3,
-
-    // top_k: 20,
-    // do_sample: true,
 });
 ```
 
-which outputs:
+Logging `result[0].generated_text` to the console gives:
 
 ```
 Cheese, oh cheese! You're the perfect comfort food.

--- a/src/pipelines.js
+++ b/src/pipelines.js
@@ -479,7 +479,7 @@ export class FillMaskPipeline extends Pipeline {
  * let output = await generator('how can I become more healthy?', {
  *   max_new_tokens: 100,
  * });
- * // [ 'To become more healthy, you can: 1. Eat a balanced diet with plenty of fruits, vegetables, whole grains, lean proteins, and healthy fats. 2. Stay hydrated by drinking plenty of water. 3. Get enough sleep and manage stress levels. 4. Avoid smoking and excessive alcohol consumption. 5. Regularly exercise and maintain a healthy weight. 6. Practice good hygiene and sanitation. 7. Seek medical attention if you experience any health issues.' ]
+ * // [{ generated_text: "To become more healthy, you can: 1. Eat a balanced diet with plenty of fruits, vegetables, whole grains, lean proteins, and healthy fats. 2. Stay hydrated by drinking plenty of water. 3. Get enough sleep and manage stress levels. 4. Avoid smoking and excessive alcohol consumption. 5. Regularly exercise and maintain a healthy weight. 6. Practice good hygiene and sanitation. 7. Seek medical attention if you experience any health issues." }]
  * ```
  */
 export class Text2TextGenerationPipeline extends Pipeline {

--- a/src/pipelines.js
+++ b/src/pipelines.js
@@ -483,7 +483,7 @@ export class FillMaskPipeline extends Pipeline {
  * ```
  */
 export class Text2TextGenerationPipeline extends Pipeline {
-    _key = null;
+    _key = 'generated_text';
 
     /**
      * Fill the masked token in the text(s) given as inputs.

--- a/tests/generation.test.js
+++ b/tests/generation.test.js
@@ -24,7 +24,7 @@ describe('Generation parameters', () => {
         {
             const outputs = await generator(text);
 
-            const tokens = generator.tokenizer.encode(outputs[0])
+            const tokens = generator.tokenizer.encode(outputs[0].generated_text)
             expect(tokens.length).toEqual(20);
         }
 
@@ -37,7 +37,7 @@ describe('Generation parameters', () => {
                 max_new_tokens: MAX_NEW_TOKENS,
             });
 
-            const tokens = generator.tokenizer.encode(outputs[0])
+            const tokens = generator.tokenizer.encode(outputs[0].generated_text)
             expect(tokens.length).toEqual(MAX_NEW_TOKENS + 1); // + 1 due to forced BOS token
         }
 
@@ -52,7 +52,7 @@ describe('Generation parameters', () => {
                 min_length: MIN_LENGTH,
             });
 
-            const tokens = generator.tokenizer.encode(outputs[0])
+            const tokens = generator.tokenizer.encode(outputs[0].generated_text)
             expect(tokens.length).toBeGreaterThanOrEqual(MIN_LENGTH);
         }
 
@@ -67,7 +67,7 @@ describe('Generation parameters', () => {
                 min_new_tokens: MIN_NEW_TOKENS,
             });
 
-            const tokens = generator.tokenizer.encode(outputs[0])
+            const tokens = generator.tokenizer.encode(outputs[0].generated_text)
             expect(tokens.length).toBeGreaterThanOrEqual(MIN_NEW_TOKENS);
         }
 

--- a/tests/pipelines.test.js
+++ b/tests/pipelines.test.js
@@ -568,7 +568,7 @@ describe('Pipelines', () => {
                     do_sample: false
                 });
                 expect(outputs).toHaveLength(1);
-                expect(outputs[0].length).toBeGreaterThan(1);
+                expect(outputs[0].generated_text.length).toBeGreaterThan(1);
             }
 
             await generator.dispose();
@@ -593,7 +593,7 @@ describe('Pipelines', () => {
                     do_sample: false
                 });
                 expect(outputs).toHaveLength(1);
-                expect(outputs[0].length).toBeGreaterThan(10);
+                expect(outputs[0].generated_text.length).toBeGreaterThan(10);
             }
             await generator.dispose();
         }, MAX_TEST_EXECUTION_TIME);


### PR DESCRIPTION
This PR adds the `generated_text` key to the output of the `text2text-generation` pipeline, making it consistent with the python library. See [here](https://huggingface.co/docs/transformers/v4.35.0/en/main_classes/pipelines#transformers.Text2TextGenerationPipeline) for more information.