### PR TITLE
Add support for Grouped Query Attention on Llama Model

### DIFF
--- a/src/models.js
+++ b/src/models.js
@@ -3035,9 +3035,9 @@ export class LlamaPreTrainedModel extends PreTrainedModel {
         // config doesn't contain pad_token_id, so we assume it is the eos_token_id
         this.config.pad_token_id = this.config.eos_token_id
 
-        this.num_heads = this.config.num_attention_heads
+        this.num_heads = this.config.num_key_value_heads ?? this.config.num_attention_heads
         this.num_layers = this.config.num_hidden_layers
-        this.dim_kv = this.config.hidden_size / this.num_heads;
+        this.dim_kv = this.config.hidden_size / this.config.num_attention_heads
     }
 }
 /**


### PR DESCRIPTION
This change allows using models like [ahxt/llama2_xs_460M_experimental](https://huggingface.co/ahxt/llama2_xs_460M_experimental).

- Resolves #388
- See [@xenova's comment](https://github.com/xenova/transformers.js/issues/388#issuecomment-1806895025) which defines the problem and points to the solution.

## How to test

```typescript
import { AutoModelForCausalLM, AutoTokenizer } from "http://localhost:8080/dist/transformers.js";
const model_path = "Felladrin/onnx-int8-llama2_xs_460M_experimental";
const model = await AutoModelForCausalLM.from_pretrained(model_path);
const tokenizer = await AutoTokenizer.from_pretrained(model_path);
const prompt = "Q: What is the largest bird?\nA:";
const input_ids = tokenizer(prompt).input_ids;
const tokens = await model.generate(input_ids, { max_length: 20 });
console.log(tokenizer.decode(tokens[0], { skip_special_tokens: true }));
```
<img width="361" alt="image" src="https://github.com/xenova/transformers.js/assets/418083/83ce5243-5c7e-47cf-95de-fa6db12289cf">


Confirm it also works with `pipeline`:

```typescript
import { pipeline } from "http://localhost:8080/dist/transformers.js";
const generator = await pipeline( "text-generation", "Felladrin/onnx-int8-llama2_xs_460M_experimental" );
const [output] = await generator("Once upon a time,", { max_length: 20 });
console.log(output.generated_text);
```
<img width="458" alt="image" src="https://github.com/xenova/transformers.js/assets/418083/7f11007d-23e6-4ca8-bf1c-03c7ed08452a">