### PR TITLE
Implement max character check

### DIFF
--- a/src/tokenizers.js
+++ b/src/tokenizers.js
@@ -270,6 +270,7 @@ class WordPieceTokenizer extends TokenizerModel {
      * @param {Object} config.vocab A mapping of tokens to ids.
      * @param {string} config.unk_token The unknown token string.
      * @param {string} config.continuing_subword_prefix The prefix to use for continuing subwords.
+     * @param {number} [config.maxInputCharsPerWord=100] The maximum number of characters per word.
      */
     constructor(config) {
         super(config);
@@ -292,6 +293,12 @@ class WordPieceTokenizer extends TokenizerModel {
         this.unk_token = config.unk_token;
 
         /**
+         * The maximum number of characters allowed per word.
+         * @type {number}
+         */
+        this.maxInputCharsPerWord = config.maxInputCharsPerWord || 100;
+
+        /**
          * An array of tokens.
          * @type {string[]}
          */
@@ -310,10 +317,10 @@ class WordPieceTokenizer extends TokenizerModel {
         let outputTokens = [];
         for (let token of tokens) {
             let chars = [...token];
-            // TODO add
-            // if len(chars) > self.max_input_chars_per_word:
-            //     output_tokens.append(self.unk_token)
-            //     continue
+            if (chars.length > this.maxInputCharsPerWord) {
+                outputTokens.push(this.unk_token);
+                continue;
+            }
 
             let isUnknown = false;
             let start = 0;

--- a/src/tokenizers.js
+++ b/src/tokenizers.js
@@ -270,7 +270,7 @@ class WordPieceTokenizer extends TokenizerModel {
      * @param {Object} config.vocab A mapping of tokens to ids.
      * @param {string} config.unk_token The unknown token string.
      * @param {string} config.continuing_subword_prefix The prefix to use for continuing subwords.
-     * @param {number} [config.maxInputCharsPerWord=100] The maximum number of characters per word.
+     * @param {number} [config.max_input_chars_per_word=100] The maximum number of characters per word.
      */
     constructor(config) {
         super(config);

--- a/src/tokenizers.js
+++ b/src/tokenizers.js
@@ -317,7 +317,7 @@ class WordPieceTokenizer extends TokenizerModel {
         let outputTokens = [];
         for (let token of tokens) {
             let chars = [...token];
-            if (chars.length > this.maxInputCharsPerWord) {
+            if (chars.length > this.max_input_chars_per_word) {
                 outputTokens.push(this.unk_token);
                 continue;
             }

--- a/src/tokenizers.js
+++ b/src/tokenizers.js
@@ -296,7 +296,7 @@ class WordPieceTokenizer extends TokenizerModel {
          * The maximum number of characters allowed per word.
          * @type {number}
          */
-        this.maxInputCharsPerWord = config.maxInputCharsPerWord || 100;
+        this.max_input_chars_per_word = config.max_input_chars_per_word ?? 100;
 
         /**
          * An array of tokens.


### PR DESCRIPTION
Returns unknown token for strings greater than param maxInputCharsPerWord (defaulting to 100). Fixes #397 