### PR TITLE
Webpack: add/build RTI target

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "sharp": "^0.32.0"
       },
       "devDependencies": {
+        "@runtime-type-inspector/plugin-webpack5": "^1.1.2",
         "@types/jest": "^29.5.1",
         "catharsis": "github:xenova/catharsis",
         "copy-webpack-plugin": "^11.0.0",
@@ -1286,6 +1287,34 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
+    "node_modules/@runtime-type-inspector/plugin-webpack5": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@runtime-type-inspector/plugin-webpack5/-/plugin-webpack5-1.1.2.tgz",
+      "integrity": "sha512-dOwY7sVUP0HeEee9IaLk5RVWRI1Wn3otHZ1KDcvul4jkSDSwWwExO5F00XTdTEMNI1hcCIif8xdpYVkTaCi9rw==",
+      "dev": true,
+      "dependencies": {
+        "@runtime-type-inspector/transpiler": "^2.1.1",
+        "loader-utils": "^2.0.4",
+        "webpack": "^5.89.0"
+      }
+    },
+    "node_modules/@runtime-type-inspector/runtime": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@runtime-type-inspector/runtime/-/runtime-2.0.8.tgz",
+      "integrity": "sha512-bNgQ8JU3Sir0YOHFIkTTI3z3VJL6eD15JevZsm10Uq/E9Q76Ss20qFsEtfbEvu7DC/4CUTWk4N0amrwKJFySwg==",
+      "dev": true
+    },
+    "node_modules/@runtime-type-inspector/transpiler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@runtime-type-inspector/transpiler/-/transpiler-2.1.1.tgz",
+      "integrity": "sha512-glU4uwRBu0zAlu8g8FmMHVu8QZLCA+WFYGdeIblVfGsY2IeUQM4FtJitYY14NQMshHlYexUL40kWtappp5qhxg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.2.0",
+        "@runtime-type-inspector/runtime": "^2.0.8",
+        "typescript": "^5.1.6"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -1839,9 +1868,9 @@
       }
     },
     "node_modules/acorn-import-assertions": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
-      "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
+      "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
       "dev": true,
       "peerDependencies": {
         "acorn": "^8"
@@ -2152,6 +2181,15 @@
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
       "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==",
       "dev": true
+    },
+    "node_modules/big.js": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
@@ -3133,6 +3171,15 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
+    "node_modules/emojis-list": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+      "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -3151,9 +3198,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.13.0.tgz",
-      "integrity": "sha512-eyV8f0y1+bzyfh8xAwW/WTSZpLbjhqc4ne9eGSH4Zo2ejdyiNG9pU6mf9DG8a7+Auk6MFTlNOT4Y2y/9k8GKVg==",
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.15.0.tgz",
+      "integrity": "sha512-LXYT42KJ7lpIKECr2mAXIaMldcNCh/7E0KBKOu4KSfkHmP+mZmSs+8V5gBAqisWBy0OO4W5Oyys0GO1Y8KtdKg==",
       "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -5277,6 +5324,20 @@
         "node": ">=6.11.5"
       }
     },
+    "node_modules/loader-utils": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
+      "dev": true,
+      "dependencies": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=8.9.0"
+      }
+    },
     "node_modules/locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -6519,9 +6580,9 @@
       "dev": true
     },
     "node_modules/schema-utils": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.2.tgz",
-      "integrity": "sha512-pvjEHOgWc9OWA/f/DE3ohBWTD6EleVLf7iFUkoSwAxttdBhB9QUebQgxER2kWueOvRJXPHNnyrvvh9eZINB8Eg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.8",
@@ -7614,9 +7675,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.80.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.80.0.tgz",
-      "integrity": "sha512-OIMiq37XK1rWO8mH9ssfFKZsXg4n6klTEDL7S8/HqbAOBBaiy8ABvXvz0dDCXeEF9gqwxSvVk611zFPjS8hJxA==",
+      "version": "5.89.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
+      "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
       "dev": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
@@ -7625,10 +7686,10 @@
         "@webassemblyjs/wasm-edit": "^1.11.5",
         "@webassemblyjs/wasm-parser": "^1.11.5",
         "acorn": "^8.7.1",
-        "acorn-import-assertions": "^1.7.6",
+        "acorn-import-assertions": "^1.9.0",
         "browserslist": "^4.14.5",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.13.0",
+        "enhanced-resolve": "^5.15.0",
         "es-module-lexer": "^1.2.1",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
@@ -7638,7 +7699,7 @@
         "loader-runner": "^4.2.0",
         "mime-types": "^2.1.27",
         "neo-async": "^2.6.2",
-        "schema-utils": "^3.1.2",
+        "schema-utils": "^3.2.0",
         "tapable": "^2.1.1",
         "terser-webpack-plugin": "^5.3.7",
         "watchpack": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "onnxruntime-node": "1.14.0"
   },
   "devDependencies": {
+    "@runtime-type-inspector/plugin-webpack5": "^1.1.2",
     "@types/jest": "^29.5.1",
     "catharsis": "github:xenova/catharsis",
     "copy-webpack-plugin": "^11.0.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,26 +2,24 @@ import CopyWebpackPlugin from 'copy-webpack-plugin';
 import TerserPlugin from 'terser-webpack-plugin';
 import { fileURLToPath } from 'url';
 import path from 'path';
+import { RuntimeTypeInspectorPlugin } from '@runtime-type-inspector/plugin-webpack5';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-export default {
-    mode: 'development',
-    devtool: 'source-map',
-    entry: {
+/**
+ * Build a target that webpack is supposed to build.
+ *
+ * @param {'release'|'rti'} buildType - The build type.
+ * @returns {import('webpack').Configuration} One webpack target.
+ */
+function buildTarget(buildType) {
+    let entry = {
         // include dist in entry point so that when running dev server,
         // we can access the files with /dist/...
         'dist/transformers': './src/transformers.js',
         'dist/transformers.min': './src/transformers.js',
-    },
-    output: {
-        filename: '[name].js',
-        path: __dirname,
-        library: {
-            type: 'module',
-        },
-    },
-    plugins: [
+    };
+    let plugins = [
         // Copy .wasm files to dist folder
         new CopyWebpackPlugin({
             patterns: [
@@ -30,22 +28,47 @@ export default {
                     to: 'dist/[name][ext]'
                 },
             ],
-        }),
-    ],
-    optimization: {
-        minimize: true,
-        minimizer: [new TerserPlugin({
-            test: /\.min\.js$/,
-            extractComments: false,
-        })],
-    },
-    devServer: {
-        static: {
-            directory: __dirname
+        })
+    ];
+    if (buildType === 'rti') {
+        entry = {
+            'dist/transformers.rti': './src/transformers.js',
+        };
+        plugins = [
+            new RuntimeTypeInspectorPlugin()
+        ];
+    }
+    return {
+        mode: 'development',
+        devtool: 'source-map',
+        entry,
+        output: {
+            filename: '[name].js',
+            path: __dirname,
+            library: {
+                type: 'module',
+            },
         },
-        port: 8080
-    },
-    experiments: {
-        outputModule: true,
-    },
-};
+        plugins,
+        optimization: {
+            minimize: buildType === 'release',
+            minimizer: [new TerserPlugin({
+                test: /\.min\.js$/,
+                extractComments: false,
+            })],
+        },
+        devServer: {
+            static: {
+                directory: __dirname
+            },
+            port: 8080
+        },
+        experiments: {
+            outputModule: true,
+        },
+    };
+}
+export default [
+    buildTarget('release'),
+    buildTarget('rti'),
+];


### PR DESCRIPTION
I'm excited to introduce [RuntimeTypeInspector.js](https://runtimetypeinspector.org/), which I believe will benefit Transformers.js as a whole and our debugging workflows in specific. RTI is designed to type-check the arguments of every function and method. It detects type errors while the engine is running in a way that goes beyond the capabilities of TypeScript, as demonstrated in [this video](https://www.youtube.com/watch?v=o5ipQe2rVKQ) (there is another one on the website debugging the Microsoft Holometric Video PC project).

During the development of RTI it already helped me to understand and fix things, for example various JSDoc types and this NaN bug: https://github.com/xenova/transformers.js/issues/390

I believe that RTI will help improve productivity and efficiency, by catching errors early on and reporting them in detail.

Runtime Type Inspector is implemented using Babel AST traversal with custom JSDoc parsing (powered by TypeScript itself for highest compatibility).

TLDR: It adds type assertions for runtime type checking, for example:

![image](https://github.com/xenova/transformers.js/assets/5236548/b1287740-4240-4e5c-b345-dc523dce08c6)

Being able to set breakpoints exactly where the errors are happening for the first time helps to track down problems that are otherwise difficult to pinpoint (and saves a lot of time :sweat_smile:).

Try for yourself: https://pc.runtimetypeinspector.org/#/animation/blend-trees-2d-cartesian

Just make sure to pick the right JS context - the exampleIframe:

![image](https://github.com/playcanvas/engine/assets/5236548/df2d8a9a-4b88-4f67-9942-3ad0b7a63632)

I'm working on this for quite some time by now, a mix of fun and frustration - rewriting code on the AST level first seemed tricky, but given enough time, it was a rather straightforward way to automate type validations. I'm excited to read feedback and suggestions. :pray: 