### PR TITLE
JSDoc type fixes

### DIFF
--- a/src/models.js
+++ b/src/models.js
@@ -1228,7 +1228,7 @@ export class PreTrainedModel extends Callable {
      * Returns an object containing past key values from the given decoder results object.
      *
      * @param {Object} decoderResults The decoder results object.
-     * @param {Object} pastKeyValues The previous past key values.
+     * @param {Object} [pastKeyValues] The previous past key values.
      * @returns {Object} An object containing past key values.
      */
     getPastKeyValues(decoderResults, pastKeyValues) {
@@ -1278,7 +1278,7 @@ export class PreTrainedModel extends Callable {
      * Adds past key values to the decoder feeds object. If pastKeyValues is null, creates new tensors for past key values.
      *
      * @param {Object} decoderFeeds The decoder feeds object to add past key values to.
-     * @param {Object} pastKeyValues An object containing past key values.
+     * @param {Object} [pastKeyValues] An object containing past key values.
      */
     addPastKeyValues(decoderFeeds, pastKeyValues) {
         if (pastKeyValues) {

--- a/src/utils/core.js
+++ b/src/utils/core.js
@@ -11,8 +11,8 @@
 /**
  * Helper function to dispatch progress callbacks.
  *
- * @param {Function} progress_callback The progress callback function to dispatch.
- * @param {any} data The data to pass to the progress callback function.
+ * @param {Function} [progress_callback] The progress callback function to dispatch.
+ * @param {any} [data] The data to pass to the progress callback function.
  * @returns {void}
  * @private
  */


### PR DESCRIPTION
While implementing the runtime type inspector in #409, I come across various type issues that I would like to fix in this standalone PR for easier discussion.

I'm figuring this out on a per-example basis and SpeechT5 is down to 3 errors now:

![image](https://github.com/xenova/transformers.js/assets/5236548/0a686f88-fcd2-44da-ab4e-7252af4a24f9)

The `config.behavior` type issue is about a discrepancy between between this type:

https://github.com/xenova/transformers.js/blob/768a2e26d7f34746caa2b102f55dbd270c5d6f36/src/tokenizers.js#L1317-L1319

And this Python JSON generator code: 

https://github.com/xenova/transformers.js/blob/768a2e26d7f34746caa2b102f55dbd270c5d6f36/scripts/extra/speecht5.py#L40-L47

Should we use "Isolated" or "isolated"? I don't know which one is "right", the only occurance of "isolated" I can find is here:

https://github.com/huggingface/transformers/blob/35551f9a0f66a22de4971b4a51b3c172d3b87f95/src/transformers/convert_slow_tokenizer.py#L633-L639