### PR TITLE
Fix zero-shot-object-detection `{percentage: true}` (Closes #433)

### DIFF
--- a/src/pipelines.js
+++ b/src/pipelines.js
@@ -1989,7 +1989,7 @@ export class ZeroShotObjectDetectionPipeline extends Pipeline {
         const toReturn = [];
         for (let i = 0; i < images.length; ++i) {
             const image = images[i];
-            const imageSize = [[image.height, image.width]];
+            const imageSize = percentage ? null : [[image.height, image.width]];
             const pixel_values = model_inputs.pixel_values[i].unsqueeze_(0);
 
             // Run model with both text and pixel inputs


### PR DESCRIPTION

```js
import { pipeline } from '@xenova/transformers';

let detector = await pipeline('zero-shot-object-detection', 'Xenova/owlvit-base-patch32');
let url = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/astronaut.png';
let candidate_labels = ['human face', 'rocket', 'helmet', 'american flag'];
let output = await detector(url, candidate_labels, { percentage: true });
```

now gives the correct values:
```
[
  {
    score: 0.24392342567443848,
    label: 'human face',
    box: {
      xmin: 0.3518258333206177,
      ymin: 0.13267339766025543,
      xmax: 0.5354219079017639,
      ymax: 0.34229128062725067
    }
  },
  {
    score: 0.15129457414150238,
    label: 'american flag',
    box: {
      xmin: 0.00013791024684906006,
      ymin: 0.00891384482383728,
      xmax: 0.2080029994249344,
      ymax: 1.0034648478031158
    }
  },
  {
    score: 0.13649864494800568,
    label: 'helmet',
    box: {
      xmin: 0.5427331179380417,
      ymin: 0.6583812534809113,
      xmax: 0.9982491284608841,
      ymax: 0.9989933669567108
    }
  },
  {
    score: 0.10262022167444229,
    label: 'rocket',
    box: {
      xmin: 0.6892154216766357,
      ymin: -0.0028268098831176758,
      xmax: 0.9050829410552979,
      ymax: 0.561252236366272
    }
  }
]
```
