### PR TITLE
Supporting Multithreading in Web Extensions

### DIFF
--- a/examples/extension/public/manifest.json
+++ b/examples/extension/public/manifest.json
@@ -8,7 +8,8 @@
     "scripting",
     "contextMenus",
     "storage",
-    "unlimitedStorage"
+    "unlimitedStorage",
+    "offscreen"
   ],
   "background": {
     "service_worker": "background.js",

--- a/examples/extension/public/manifest.json
+++ b/examples/extension/public/manifest.json
@@ -38,6 +38,11 @@
   "content_security_policy": {
     "extension_pages": "script-src 'self' 'wasm-unsafe-eval'"
   },
+  "sandbox": {
+    "pages": [
+      "sandbox.html"
+    ]
+  },
   "icons": {
     "16": "icons/icon.png",
     "48": "icons/icon.png",

--- a/examples/extension/public/offscreen.html
+++ b/examples/extension/public/offscreen.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<script src="offscreen.js" type="module"></script>

--- a/examples/extension/public/offscreen.html
+++ b/examples/extension/public/offscreen.html
@@ -1,2 +1,12 @@
 <!DOCTYPE html>
-<script src="offscreen.js" type="module"></script>
+<html lang="en">
+
+<head>
+    <script src="offscreen.js" type="module"></script>
+</head>
+
+<body>
+    <iframe src="sandbox.html" id="sandbox"></iframe>
+</body>
+
+</html>

--- a/examples/extension/public/sandbox.html
+++ b/examples/extension/public/sandbox.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<script src="sandbox.js" type="module"></script>

--- a/examples/extension/src/offscreen.js
+++ b/examples/extension/src/offscreen.js
@@ -1,0 +1,57 @@
+// offscreen.js - Handles requests from the background service worker, runs the model, then sends back a response
+
+// Registering this listener when the script is first executed ensures that the
+// offscreen document will be able to receive messages when the promise returned
+// by `offscreen.createDocument()` resolves.
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+    console.log("sender", sender)
+    console.log('message', message)
+    if (message.target !== 'offscreen') {
+        return false;
+    }
+    switch (message.type) {
+        case 'classify':
+            classify(message.data).then(result => {
+                sendResponse({ type: 'result', result });
+            });
+            return true;
+        default:
+            console.warn(`Unexpected message type received: '${message.type}'.`);
+            return false;
+    }
+});
+
+import { pipeline, env } from '@xenova/transformers';
+
+// Skip initial check for local models, since we are not loading any local models.
+env.allowLocalModels = false;
+
+class PipelineSingleton {
+    static task = 'text-classification';
+    static model = 'Xenova/distilbert-base-uncased-finetuned-sst-2-english';
+    static instance = null;
+
+    static async getInstance(progress_callback = null) {
+        if (this.instance === null) {
+            this.instance = pipeline(this.task, this.model, { progress_callback });
+        }
+
+        return this.instance;
+    }
+}
+
+// Create generic classify function, which will be reused for the different types of events.
+const classify = async (text) => {
+    // Get the pipeline instance. This will load and build the model when run for the first time.
+    let model = await PipelineSingleton.getInstance((data) => {
+        // You can track the progress of the pipeline creation here.
+        // e.g., you can send `data` back to the UI to indicate a progress bar
+        // console.log('progress', data)
+    });
+
+    // Actually run the model on the input text
+    let result = await model(text);
+    return result;
+};
+
+

--- a/examples/extension/src/sandbox.js
+++ b/examples/extension/src/sandbox.js
@@ -1,0 +1,44 @@
+import { pipeline, env } from '@xenova/transformers';
+
+// Skip initial check for local models, since we are not loading any local models.
+env.allowLocalModels = false;
+env.useBrowserCache = false; // for now: caches in sandox might be tricky.
+
+class PipelineSingleton {
+    static task = 'text-classification';
+    static model = 'Xenova/distilbert-base-uncased-finetuned-sst-2-english';
+    static instance = null;
+
+    static async getInstance(progress_callback = null) {
+        if (this.instance === null) {
+            this.instance = pipeline(this.task, this.model, { progress_callback });
+        }
+
+        return this.instance;
+    }
+}
+
+// Create generic classify function, which will be reused for the different types of events.
+const classify = async (text) => {
+    // Get the pipeline instance. This will load and build the model when run for the first time.
+    let model = await PipelineSingleton.getInstance((data) => {
+        // You can track the progress of the pipeline creation here.
+        // e.g., you can send `data` back to the UI to indicate a progress bar
+        // console.log('progress', data)
+    });
+
+    // Actually run the model on the input text
+    let result = await model(text);
+    return result;
+};
+
+window.addEventListener('message', function (event) {
+    console.log('message received in sandbox', event)
+    try {
+        classify(event.data).then(result => {
+            event.ports[0].postMessage({ result });
+        })
+    } catch (e) {
+        event.ports[0].postMessage({ error: e });
+    }
+}, false)

--- a/examples/extension/webpack.config.js
+++ b/examples/extension/webpack.config.js
@@ -14,7 +14,8 @@ const config = {
         background: './src/background.js',
         popup: './src/popup.js',
         content: './src/content.js',
-        offscreen: './src/offscreen.js'
+        offscreen: './src/offscreen.js',
+        sandbox: './src/sandbox.js'
     },
     output: {
         path: path.resolve(__dirname, 'build'),

--- a/examples/extension/webpack.config.js
+++ b/examples/extension/webpack.config.js
@@ -14,6 +14,7 @@ const config = {
         background: './src/background.js',
         popup: './src/popup.js',
         content: './src/content.js',
+        offscreen: './src/offscreen.js'
     },
     output: {
         path: path.resolve(__dirname, 'build'),


### PR DESCRIPTION
Per [discussion on microsoft/onnxruntime ](https://github.com/microsoft/onnxruntime/issues/14445#issuecomment-1847675537), I took a stab at implementing the extension example using an [offscreen document](https://developer.chrome.com/docs/extensions/reference/api/offscreen) in order to support multiple threads.  There are a few serious drawbacks to this approach that I lay out below, including that the offscreen document seems to interfere with the popup window, so only the context menu workflow works in this PR.  But I thought I'd post and give y'all  a chance to review and think through next steps.

Overall, things turned out to be a bit more complicated than I thought:

- While the initial issue with multithreading seemed to be that the `background.js` service worker couldn't support the onnx runtime's calls to `URL.createObjectURL`, it turned out that the background service worker _also_ will not support the creation of new web Workers, which onnx creates when entering multi-threading mode.  So even if we convinced microsoft/onnxruntime to avoid calls to `URL.createObjectURL`, it still wouldn't be possible to run multithreaded inference in the `background.js` service worker.  Fortunately, creation of Workers is [another valid reason for using an offscreen document](https://developer.chrome.com/docs/extensions/reference/api/offscreen#type-Reason).
- Even within an offscreen document, the way that onnx's creates new threads will throw errors for violating Chrome extensions' Content Security Policy.  To get around _that_ I load and run the model in a [sandboxed](https://developer.chrome.com/docs/extensions/reference/manifest/sandbox) iframe within the offscreen page.

This offscreen page+sandbox iframe strategy does seem to allow for multithreading, but it has a couple of undesirable properties that might mean needing to try something else entirely.

- Offscreen documents don't really seem intended for staying open for long periods, whereas in this case the offscreen document needs to stay open pretty much indefinitely so that it can load the model once and have it available for multiple inferences. One very serious implication of having the offscreen document open all the time is that it seems to break the `popup` action -- at least I couldn't get the popup to appear after I had initialized the offscreen document.  So this PR only works for the workflow where a user selects text and hits "classify" in the context window.  One way forward here might be to see if the popup window (and potentially the offscreen document?) can be replaced by a Chrome [Side Panel](https://developer.chrome.com/docs/extensions/reference/api/sidePanel).
- The sandbox does not have access to the Cache API, which I dealt with by setting `env.useBrowserCache = false`.  There might be ways around this but I haven't given it much thought.

Anyway, interested to hear your thoughts.  If there's interest in exploring the SidePanel approach I'd be happy to take a look and post another PR.