### PR TITLE
Add spaces template link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Want to jump straight in? Get started with one of our sample applications/templa
 | Node.js           | Sentiment analysis API           | [code](./examples/node/)      |
 | Demo site         | A collection of demos | [code](./examples/demo-site/), [demo](https://xenova.github.io/transformers.js/) |
 
+Check out the Transformers.js [template](https://huggingface.co/new-space?template=static-templates%2Ftransformers.js) on Hugging Face to get started in one click!
 
 
 ## Custom usage

--- a/docs/snippets/3_examples.snippet
+++ b/docs/snippets/3_examples.snippet
@@ -17,3 +17,4 @@ Want to jump straight in? Get started with one of our sample applications/templa
 | Node.js           | Sentiment analysis API           | [code](./examples/node/)      |
 | Demo site         | A collection of demos | [code](./examples/demo-site/), [demo](https://xenova.github.io/transformers.js/) |
 
+Check out the Transformers.js [template](https://huggingface.co/new-space?template=static-templates%2Ftransformers.js) on Hugging Face to get started in one click!


### PR DESCRIPTION
Adds spaces template link (https://huggingface.co/new-space?template=static-templates%2Ftransformers.js) to README and examples section.

![image](https://github.com/xenova/transformers.js/assets/26504141/80d5a1a9-c261-48e0-94d5-7475b5ff7c03)

Demo: https://huggingface.co/spaces/static-templates/transformers.js

cc @osanseviero