### PR TITLE
Improve typing of `pipeline` helper function

### DIFF
--- a/src/models.js
+++ b/src/models.js
@@ -813,7 +813,7 @@ export class PreTrainedModel extends Callable {
     }
 
     /**
-     * @param {GenerationConfig} generation_config 
+     * @param {import('./utils/generation.js').GenerationConfigType} generation_config 
      * @param {number} input_ids_seq_length The starting sequence length for the input ids.
      * @returns {LogitsProcessorList}
      * @private
@@ -943,9 +943,8 @@ export class PreTrainedModel extends Callable {
     /**
      * This function merges multiple generation configs together to form a final generation config to be used by the model for text generation.
      * It first creates an empty `GenerationConfig` object, then it applies the model's own `generation_config` property to it. Finally, if a `generation_config` object was passed in the arguments, it overwrites the corresponding properties in the final config with those of the passed config object.
-     *
-     * @param {GenerationConfig} generation_config A `GenerationConfig` object containing generation parameters.
-     * @returns {GenerationConfig} The final generation config object to be used by the model for text generation.
+     * @param {import('./utils/generation.js').GenerationConfigType} generation_config A `GenerationConfig` object containing generation parameters.
+     * @returns {import('./utils/generation.js').GenerationConfigType} The final generation config object to be used by the model for text generation.
      */
     _get_generation_config(generation_config) {
         // Create empty generation config (contains defaults)

--- a/src/pipelines.js
+++ b/src/pipelines.js
@@ -2563,6 +2563,16 @@ export class ImageToImagePipeline extends (/** @type {new (options: ImagePipelin
 }
 
 /**
+ * @typedef {Object} DepthEstimationPipelineOutput
+ * @property {Tensor} predicted_depth The raw depth map predicted by the model.
+ * @property {RawImage} depth The processed depth map as an image (with the same size as the input image).
+ * 
+ * @callback DepthEstimationPipelineCallback Predicts the depth for the image(s) passed as inputs.
+ * @param {ImagePipelineInputs} images The images to compute depth for.
+ * @returns {Promise<DepthEstimationPipelineOutput|DepthEstimationPipelineOutput[]>} An image or a list of images containing result(s).
+ */
+
+/**
  * Depth estimation pipeline using any `AutoModelForDepthEstimation`. This pipeline predicts the depth of an image.
  * 
  * **Example:** Depth estimation w/ `Xenova/dpt-hybrid-midas`
@@ -2586,7 +2596,7 @@ export class ImageToImagePipeline extends (/** @type {new (options: ImagePipelin
  * // }
  * ```
  */
-export class DepthEstimationPipeline extends Pipeline {
+export class DepthEstimationPipeline extends (/** @type {new (options: ImagePipelineConstructorArgs) => DepthEstimationPipelineCallback} */ (/** @type {any} */ Pipeline)) {
     /**
      * Create a new DepthEstimationPipeline.
      * @param {ImagePipelineConstructorArgs} options An object used to instantiate the pipeline.
@@ -2595,16 +2605,14 @@ export class DepthEstimationPipeline extends Pipeline {
         super(options);
     }
 
-    /**
-     * Predicts the depth for the image(s) passed as inputs.
-     * @param {ImagePipelineInputs} images The images to compute depth for.
-     * @returns {Promise<any>} An image or a list of images containing result(s).
-     */
+    /** @type {DepthEstimationPipelineCallback} */
     async _call(images) {
+        const self = /** @type {DepthEstimationPipeline & Pipeline} */ (/** @type {any} */ (this));
+
         const preparedImages = await prepareImages(images);
 
-        const inputs = await this.processor(preparedImages);
-        const { predicted_depth } = await this.model(inputs);
+        const inputs = await self.processor(preparedImages);
+        const { predicted_depth } = await self.model(inputs);
 
         const toReturn = [];
         for (let i = 0; i < preparedImages.length; ++i) {

--- a/src/pipelines.js
+++ b/src/pipelines.js
@@ -561,7 +561,7 @@ export class Text2TextGenerationPipeline extends (/** @type {new (_) => Text2Tex
             truncation: true,
         }
         let input_ids;
-        if (self instanceof TranslationPipeline && '_build_translation_inputs' in self.tokenizer) {
+        if (self instanceof TranslationPipeline && '_build_translation_inputs' in /** @type {Pipeline} */ (self).tokenizer) {
             // TODO: move to Translation pipeline?
             // Currently put here to avoid code duplication
             // @ts-ignore
@@ -579,6 +579,17 @@ export class Text2TextGenerationPipeline extends (/** @type {new (_) => Text2Tex
     }
 }
 
+
+/**
+ * @typedef {Object} SummarizationGenerationSingle
+ * @property {string} summary_text The summary text.
+ * @typedef {SummarizationGenerationSingle[]} SummarizationGenerationOutput
+ * 
+ * @callback SummarizationGenerationPipelineCallback Summarize the text(s) given as inputs.
+ * @param {string|string[]} texts One or several articles (or one list of articles) to summarize.
+ * @param {import('./utils/generation.js').GenerationConfigType} options Additional keyword arguments to pass along to the generate method of the model
+ * @returns {Promise<SummarizationGenerationOutput|SummarizationGenerationOutput[]>}
+ */
 
 /**
  * A pipeline for summarization tasks, inheriting from Text2TextGenerationPipeline.
@@ -601,9 +612,22 @@ export class Text2TextGenerationPipeline extends (/** @type {new (_) => Text2Tex
  * // [{ summary_text: ' The Eiffel Tower is about the same height as an 81-storey building and the tallest structure in Paris. It is the second tallest free-standing structure in France after the Millau Viaduct.' }]
  * ```
  */
-export class SummarizationPipeline extends Text2TextGenerationPipeline {
+export class SummarizationPipeline extends (/** @type {new (_) => SummarizationGenerationPipelineCallback} */ (/** @type {any} */ (Text2TextGenerationPipeline))) {
+    /** @type {'summary_text'} */
     _key = 'summary_text';
 }
+
+
+/**
+ * @typedef {Object} TranslationGenerationSingle
+ * @property {string} translation_text The translated text.
+ * @typedef {TranslationGenerationSingle[]} TranslationGenerationOutput
+ * 
+ * @callback TranslationGenerationPipelineCallback Translate the text(s) given as inputs.
+ * @param {string|string[]} texts Texts to be translated.
+ * @param {import('./utils/generation.js').GenerationConfigType} options Additional keyword arguments to pass along to the generate method of the model
+ * @returns {Promise<TranslationGenerationOutput|TranslationGenerationOutput[]>}
+ */
 
 /**
  * Translates text from one language to another.
@@ -650,7 +674,8 @@ export class SummarizationPipeline extends Text2TextGenerationPipeline {
  * // [{ translation_text: 'Le chef des Nations affirme qu 'il n 'y a military solution in Syria.' }]
  * ```
  */
-export class TranslationPipeline extends Text2TextGenerationPipeline {
+export class TranslationPipeline extends (/** @type {new (_) => TranslationGenerationPipelineCallback} */ (/** @type {any} */ (Text2TextGenerationPipeline))) {
+    /** @type {'translation_text'} */
     _key = 'translation_text';
 }
 

--- a/src/pipelines.js
+++ b/src/pipelines.js
@@ -99,7 +99,7 @@ async function prepareImages(images) {
  * Prepare audios for further tasks.
  * @param {AudioPipelineInputs} audios audios to prepare.
  * @param {number} sampling_rate sampling rate of the audios.
- * @returns {Promise<Float32Array[]>} A promise that resolves to the preprocessed audio data.
+ * @returns {Promise<Float32Array[]>} The preprocessed audio data.
  * @private
  */
 async function prepareAudios(audios, sampling_rate) {
@@ -213,7 +213,7 @@ export class Pipeline extends Callable {
  * @param {string|string[]} texts The input text(s) to be classified.
  * @param {Object} options An optional object containing the following properties:
  * @param {number} [options.topk=1] The number of top predictions to be returned.
- * @returns {Promise<TextClassificationOutput|TextClassificationOutput[]>} A promise that resolves to an array or object containing the predicted labels and scores.
+ * @returns {Promise<TextClassificationOutput|TextClassificationOutput[]>} An array or object containing the predicted labels and scores.
  */
 
 /**
@@ -320,7 +320,7 @@ export class TextClassificationPipeline extends (/** @type {new (options: TextPi
  * @param {string|string[]} texts One or several texts (or one list of texts) for token classification.
  * @param {Object} options An optional object containing the following properties:
  * @param {string[]} [options.ignore_labels] A list of labels to ignore.
- * @returns {Promise<TokenClassificationOutput|TokenClassificationOutput[]>} A promise that resolves to the result.
+ * @returns {Promise<TokenClassificationOutput|TokenClassificationOutput[]>} The result.
  */
 
 /**
@@ -437,8 +437,7 @@ export class TokenClassificationPipeline extends (/** @type {new (options: TextP
  * @param {string|string[]} context One or several context(s) associated with the question(s) (must be used in conjunction with the `question` argument).
  * @param {Object} options An optional object containing the following properties:
  * @param {number} [options.topk=1] The number of top answer predictions to be returned.
- * @returns {Promise<QuestionAnsweringOutput|QuestionAnsweringOutput[]>} A promise that resolves to an array or object
- * containing the predicted answers and scores.
+ * @returns {Promise<QuestionAnsweringOutput|QuestionAnsweringOutput[]>} An array or object containing the predicted answers and scores.
  */
 
 /**
@@ -831,7 +830,7 @@ export class TranslationPipeline extends (/** @type {new (options: TextPipelineC
  * @callback TextGenerationPipelineCallback Complete the prompt(s) given as inputs.
  * @param {string|string[]} texts One or several prompts (or one list of prompts) to complete.
  * @param {TextGenerationConfig} options Additional keyword arguments to pass along to the generate method of the model.
- * @returns {Promise<TextGenerationOutput|TextGenerationOutput[]>} A promise that resolves to an array or object containing the generated texts.
+ * @returns {Promise<TextGenerationOutput|TextGenerationOutput[]>} An array or object containing the generated texts.
  */
 
 /**
@@ -951,7 +950,7 @@ export class TextGenerationPipeline extends (/** @type {new (options: TextPipeli
  * If `false`, the scores are normalized such that the sum of the label likelihoods for each sequence
  * is 1. If `true`, the labels are considered independent and probabilities are normalized for each
  * candidate by doing a softmax of the entailment score vs. the contradiction score.
- * @returns {Promise<ZeroShotClassificationOutput|ZeroShotClassificationOutput[]>} A promise that resolves to an array or object containing the predicted labels and scores.
+ * @returns {Promise<ZeroShotClassificationOutput|ZeroShotClassificationOutput[]>} An array or object containing the predicted labels and scores.
  */
 
 /**
@@ -1198,7 +1197,7 @@ export class FeatureExtractionPipeline extends (/** @type {new (options: TextPip
  * @param {number} [options.topk=null] The number of top labels that will be returned by the pipeline.
  * If the provided number is `null` or higher than the number of labels available in the model configuration,
  * it will default to the number of labels.
- * @returns {Promise<AudioClassificationOutput|AudioClassificationOutput[]>} A promise that resolves to an array or object containing the predicted labels and scores.
+ * @returns {Promise<AudioClassificationOutput|AudioClassificationOutput[]>} An array or object containing the predicted labels and scores.
  */
 
 /**
@@ -1291,7 +1290,7 @@ export class AudioClassificationPipeline extends (/** @type {new (options: Audio
  * @param {string} [options.hypothesis_template="This is a sound of {}."] The sentence used in conjunction with `candidate_labels`
  * to attempt the audio classification by replacing the placeholder with the candidate_labels.
  * Then likelihood is estimated by using `logits_per_audio`.
- * @returns {Promise<ZeroShotAudioClassificationOutput[]|ZeroShotAudioClassificationOutput[][]>} A promise that resolves to an array of objects containing the predicted labels and scores.
+ * @returns {Promise<ZeroShotAudioClassificationOutput[]|ZeroShotAudioClassificationOutput[][]>} An array of objects containing the predicted labels and scores.
  */
 
 /**
@@ -1402,8 +1401,7 @@ export class ZeroShotAudioClassificationPipeline extends (/** @type {new (option
  * If `AudioContext` is not available, you should pass the raw waveform in as a Float32Array of shape `(n, )`.
  * - `Float32Array` or `Float64Array` of shape `(n, )`, representing the raw audio at the correct sampling rate (no further check will be done).
  * @param {AutomaticSpeechRecognitionConfig} options Additional keyword arguments to pass along to the generate method of the model.
- * @returns {Promise<AutomaticSpeechRecognitionOutput|AutomaticSpeechRecognitionOutput[]>} A Promise that resolves to an object containing the
- * transcription text and optionally timestamps if `return_timestamps` is `true`.
+ * @returns {Promise<AutomaticSpeechRecognitionOutput|AutomaticSpeechRecognitionOutput[]>} An object containing the transcription text and optionally timestamps if `return_timestamps` is `true`.
  */
 
 /**
@@ -1671,7 +1669,7 @@ export class AutomaticSpeechRecognitionPipeline extends (/** @type {new (options
  * @callback ImageToTextPipelineCallback Assign labels to the image(s) passed as inputs.
  * @param {ImagePipelineInputs} texts The images to be captioned.
  * @param {import('./utils/generation.js').GenerationConfigType} options Additional keyword arguments to pass along to the generate method of the model.
- * @returns {Promise<ImageToTextOutput|ImageToTextOutput[]>} A Promise that resolves to an object (or array of objects) containing the generated text(s).
+ * @returns {Promise<ImageToTextOutput|ImageToTextOutput[]>} An object (or array of objects) containing the generated text(s).
  */
 
 /**
@@ -1736,7 +1734,7 @@ export class ImageToTextPipeline extends (/** @type {new (options: TextImagePipe
  * @param {ImagePipelineInputs} images The input images(s) to be classified.
  * @param {Object} options An optional object containing the following properties:
  * @param {number} [options.topk=1] The number of top labels that will be returned by the pipeline. 
- * @returns {Promise<ImageClassificationOutput|ImageClassificationOutput[]>} A promise that resolves to an array or object containing the predicted labels and scores.
+ * @returns {Promise<ImageClassificationOutput|ImageClassificationOutput[]>} An array or object containing the predicted labels and scores.
  */
 
 /**
@@ -1978,7 +1976,7 @@ export class ImageSegmentationPipeline extends (/** @type {new (options: ImagePi
  * @param {string} [options.hypothesis_template="This is a photo of {}"] The sentence used in conjunction with `candidate_labels`
  * to attempt the image classification by replacing the placeholder with the candidate_labels.
  * Then likelihood is estimated by using `logits_per_image`.
- * @returns {Promise<ZeroShotImageClassificationOutput[]|ZeroShotImageClassificationOutput[][]>} A promise that resolves to an array of objects containing the predicted labels and scores.
+ * @returns {Promise<ZeroShotImageClassificationOutput[]|ZeroShotImageClassificationOutput[][]>} An array of objects containing the predicted labels and scores.
  */
 
 /**
@@ -2069,7 +2067,7 @@ export class ZeroShotImageClassificationPipeline extends (/** @type {new (option
  * @param {Object} options The options for the object detection.
  * @param {number} [options.threshold=0.9] The threshold used to filter boxes by score.
  * @param {boolean} [options.percentage=false] Whether to return the boxes coordinates in percentage (true) or in pixels (false).
- * @returns {Promise<ObjectDetectionPipelineOutput|ObjectDetectionPipelineOutput[]>} A promise that resolves to a list of objects or a list of list of objects. 
+ * @returns {Promise<ObjectDetectionPipelineOutput|ObjectDetectionPipelineOutput[]>} A list of objects or a list of list of objects. 
  */
 
 /**
@@ -2160,7 +2158,7 @@ export class ObjectDetectionPipeline extends (/** @type {new (options: ImagePipe
  * If the provided number is `null` or higher than the number of predictions available, it will default
  * to the number of predictions.
  * @param {boolean} [options.percentage=false] Whether to return the boxes coordinates in percentage (true) or in pixels (false).
- * @returns {Promise<ZeroShotObjectDetectionOutput[]|ZeroShotObjectDetectionOutput[][]>} A promise that resolves to an array of objects containing the predicted labels, scores, and bounding boxes.
+ * @returns {Promise<ZeroShotObjectDetectionOutput[]|ZeroShotObjectDetectionOutput[][]>} An array of objects containing the predicted labels, scores, and bounding boxes.
  */
 
 /**
@@ -2295,7 +2293,7 @@ export class ZeroShotObjectDetectionPipeline extends (/** @type {new (options: T
  * @param {ImageInput} image The image of the document to use.
  * @param {string} question A question to ask of the document.
  * @param {import('./utils/generation.js').GenerationConfigType} options Additional keyword arguments to pass along to the generate method of the model.
- * @returns {Promise<DocumentQuestionAnsweringOutput|DocumentQuestionAnsweringOutput[]>} A Promise that resolves to an object (or array of objects) containing the answer(s).
+ * @returns {Promise<DocumentQuestionAnsweringOutput|DocumentQuestionAnsweringOutput[]>} An object (or array of objects) containing the answer(s).
  */
 
 /**
@@ -2381,7 +2379,7 @@ export class DocumentQuestionAnsweringPipeline extends (/** @type {new (options:
  * @param {Object} options Parameters passed to the model generation/forward method.
  * @param {Tensor|Float32Array|string|URL} [options.speaker_embeddings=null] The speaker embeddings (if the model requires it).
  * 
- * @returns {Promise<TextToAudioOutput>} A promise which resolves to an object containing the generated audio and sampling rate.
+ * @returns {Promise<TextToAudioOutput>} An object containing the generated audio and sampling rate.
  */
 
 /**
@@ -2515,7 +2513,7 @@ export class TextToAudioPipeline extends (/** @type {new (options: TextToAudioPi
 /**
  * @callback ImageToImagePipelineCallback Transform the image(s) passed as inputs.
  * @param {ImagePipelineInputs} images The images to transform.
- * @returns {Promise<RawImage|RawImage[]>} A promise that resolves to the transformed image or list of images.
+ * @returns {Promise<RawImage|RawImage[]>} The transformed image or list of images.
  */
 
 /**

--- a/src/pipelines.js
+++ b/src/pipelines.js
@@ -5,8 +5,8 @@
  * ```javascript
  * import { pipeline } from '@xenova/transformers';
  * 
- * let classifier = await pipeline('sentiment-analysis');
- * let output = await classifier('I love transformers!');
+ * const classifier = await pipeline('sentiment-analysis');
+ * const output = await classifier('I love transformers!');
  * // [{'label': 'POSITIVE', 'score': 0.999817686}]
  * ```
  * 
@@ -221,15 +221,15 @@ export class Pipeline extends Callable {
  *
  * **Example:** Sentiment-analysis w/ `Xenova/distilbert-base-uncased-finetuned-sst-2-english`.
  * ```javascript
- * let classifier = await pipeline('sentiment-analysis', 'Xenova/distilbert-base-uncased-finetuned-sst-2-english');
- * let output = await classifier('I love transformers!');
+ * const classifier = await pipeline('sentiment-analysis', 'Xenova/distilbert-base-uncased-finetuned-sst-2-english');
+ * const output = await classifier('I love transformers!');
  * // [{ label: 'POSITIVE', score: 0.999788761138916 }]
  * ```
  * 
  * **Example:** Multilingual sentiment-analysis w/ `Xenova/bert-base-multilingual-uncased-sentiment` (and return top 5 classes).
  * ```javascript
- * let classifier = await pipeline('sentiment-analysis', 'Xenova/bert-base-multilingual-uncased-sentiment');
- * let output = await classifier('Le meilleur film de tous les temps.', { topk: 5 });
+ * const classifier = await pipeline('sentiment-analysis', 'Xenova/bert-base-multilingual-uncased-sentiment');
+ * const output = await classifier('Le meilleur film de tous les temps.', { topk: 5 });
  * // [
  * //   { label: '5 stars', score: 0.9610759615898132 },
  * //   { label: '4 stars', score: 0.03323351591825485 },
@@ -241,8 +241,8 @@ export class Pipeline extends Callable {
  * 
  * **Example:** Toxic comment classification w/ `Xenova/toxic-bert` (and return all classes).
  * ```javascript
- * let classifier = await pipeline('text-classification', 'Xenova/toxic-bert');
- * let output = await classifier('I hate you!', { topk: null });
+ * const classifier = await pipeline('text-classification', 'Xenova/toxic-bert');
+ * const output = await classifier('I hate you!', { topk: null });
  * // [
  * //   { label: 'toxic', score: 0.9593140482902527 },
  * //   { label: 'insult', score: 0.16187334060668945 },
@@ -328,8 +328,8 @@ export class TextClassificationPipeline extends (/** @type {new (options: TextPi
  * 
  * **Example:** Perform named entity recognition with `Xenova/bert-base-NER`.
  * ```javascript
- * let classifier = await pipeline('token-classification', 'Xenova/bert-base-NER');
- * let output = await classifier('My name is Sarah and I live in London');
+ * const classifier = await pipeline('token-classification', 'Xenova/bert-base-NER');
+ * const output = await classifier('My name is Sarah and I live in London');
  * // [
  * //   { entity: 'B-PER', score: 0.9980202913284302, index: 4, word: 'Sarah' },
  * //   { entity: 'B-LOC', score: 0.9994474053382874, index: 9, word: 'London' }
@@ -338,8 +338,8 @@ export class TextClassificationPipeline extends (/** @type {new (options: TextPi
  * 
  * **Example:** Perform named entity recognition with `Xenova/bert-base-NER` (and return all labels).
  * ```javascript
- * let classifier = await pipeline('token-classification', 'Xenova/bert-base-NER');
- * let output = await classifier('Sarah lives in the United States of America', { ignore_labels: [] });
+ * const classifier = await pipeline('token-classification', 'Xenova/bert-base-NER');
+ * const output = await classifier('Sarah lives in the United States of America', { ignore_labels: [] });
  * // [
  * //   { entity: 'B-PER', score: 0.9966587424278259, index: 1, word: 'Sarah' },
  * //   { entity: 'O', score: 0.9987385869026184, index: 2, word: 'lives' },
@@ -445,11 +445,10 @@ export class TokenClassificationPipeline extends (/** @type {new (options: TextP
  * 
  * **Example:** Run question answering with `Xenova/distilbert-base-uncased-distilled-squad`.
  * ```javascript
- * let question = 'Who was Jim Henson?';
- * let context = 'Jim Henson was a nice puppet.';
- * 
- * let answerer = await pipeline('question-answering', 'Xenova/distilbert-base-uncased-distilled-squad');
- * let output = await answerer(question, context);
+ * const answerer = await pipeline('question-answering', 'Xenova/distilbert-base-uncased-distilled-squad');
+ * const question = 'Who was Jim Henson?';
+ * const context = 'Jim Henson was a nice puppet.';
+ * const output = await answerer(question, context);
  * // {
  * //   answer: "a nice puppet",
  * //   score: 0.5768911502526741
@@ -545,8 +544,8 @@ export class QuestionAnsweringPipeline extends (/** @type {new (options: TextPip
  * 
  * **Example:** Perform masked language modelling (a.k.a. "fill-mask") with `Xenova/bert-base-uncased`.
  * ```javascript
- * let unmasker = await pipeline('fill-mask', 'Xenova/bert-base-cased');
- * let output = await unmasker('The goal of life is [MASK].');
+ * const unmasker = await pipeline('fill-mask', 'Xenova/bert-base-cased');
+ * const output = await unmasker('The goal of life is [MASK].');
  * // [
  * //   { token_str: 'survival', score: 0.06137419492006302, token: 8115, sequence: 'The goal of life is survival.' },
  * //   { token_str: 'love', score: 0.03902450203895569, token: 1567, sequence: 'The goal of life is love.' },
@@ -558,8 +557,8 @@ export class QuestionAnsweringPipeline extends (/** @type {new (options: TextPip
  * 
  * **Example:** Perform masked language modelling (a.k.a. "fill-mask") with `Xenova/bert-base-cased` (and return top result).
  * ```javascript
- * let unmasker = await pipeline('fill-mask', 'Xenova/bert-base-cased');
- * let output = await unmasker('The Milky Way is a [MASK] galaxy.', { topk: 1 });
+ * const unmasker = await pipeline('fill-mask', 'Xenova/bert-base-cased');
+ * const output = await unmasker('The Milky Way is a [MASK] galaxy.', { topk: 1 });
  * // [{ token_str: 'spiral', score: 0.6299987435340881, token: 14061, sequence: 'The Milky Way is a spiral galaxy.' }]
  * ```
  */
@@ -635,8 +634,8 @@ export class FillMaskPipeline extends (/** @type {new (options: TextPipelineCons
  * 
  * **Example:** Text-to-text generation w/ `Xenova/LaMini-Flan-T5-783M`.
  * ```javascript
- * let generator = await pipeline('text2text-generation', 'Xenova/LaMini-Flan-T5-783M');
- * let output = await generator('how can I become more healthy?', {
+ * const generator = await pipeline('text2text-generation', 'Xenova/LaMini-Flan-T5-783M');
+ * const output = await generator('how can I become more healthy?', {
  *   max_new_tokens: 100,
  * });
  * // [{ generated_text: "To become more healthy, you can: 1. Eat a balanced diet with plenty of fruits, vegetables, whole grains, lean proteins, and healthy fats. 2. Stay hydrated by drinking plenty of water. 3. Get enough sleep and manage stress levels. 4. Avoid smoking and excessive alcohol consumption. 5. Regularly exercise and maintain a healthy weight. 6. Practice good hygiene and sanitation. 7. Seek medical attention if you experience any health issues." }]
@@ -718,7 +717,8 @@ export class Text2TextGenerationPipeline extends (/** @type {new (options: TextP
  * 
  * **Example:** Summarization w/ `Xenova/distilbart-cnn-6-6`.
  * ```javascript
- * let text = 'The tower is 324 metres (1,063 ft) tall, about the same height as an 81-storey building, ' +
+ * const generator = await pipeline('summarization', 'Xenova/distilbart-cnn-6-6');
+ * const text = 'The tower is 324 metres (1,063 ft) tall, about the same height as an 81-storey building, ' +
  *   'and the tallest structure in Paris. Its base is square, measuring 125 metres (410 ft) on each side. ' +
  *   'During its construction, the Eiffel Tower surpassed the Washington Monument to become the tallest ' +
  *   'man-made structure in the world, a title it held for 41 years until the Chrysler Building in New ' +
@@ -726,9 +726,7 @@ export class Text2TextGenerationPipeline extends (/** @type {new (options: TextP
  *   'the addition of a broadcasting aerial at the top of the tower in 1957, it is now taller than the ' +
  *   'Chrysler Building by 5.2 metres (17 ft). Excluding transmitters, the Eiffel Tower is the second ' +
  *   'tallest free-standing structure in France after the Millau Viaduct.';
- * 
- * let generator = await pipeline('summarization', 'Xenova/distilbart-cnn-6-6');
- * let output = await generator(text, {
+ * const output = await generator(text, {
  *   max_new_tokens: 100,
  * });
  * // [{ summary_text: ' The Eiffel Tower is about the same height as an 81-storey building and the tallest structure in Paris. It is the second tallest free-standing structure in France after the Millau Viaduct.' }]
@@ -768,8 +766,8 @@ export class SummarizationPipeline extends (/** @type {new (options: TextPipelin
  * for the full list of languages and their corresponding codes.
  * 
  * ```javascript
- * let translator = await pipeline('translation', 'Xenova/nllb-200-distilled-600M');
- * let output = await translator('जीवन एक चॉकलेट बॉक्स की तरह है।', {
+ * const translator = await pipeline('translation', 'Xenova/nllb-200-distilled-600M');
+ * const output = await translator('जीवन एक चॉकलेट बॉक्स की तरह है।', {
  *   src_lang: 'hin_Deva', // Hindi
  *   tgt_lang: 'fra_Latn', // French
  * });
@@ -782,8 +780,8 @@ export class SummarizationPipeline extends (/** @type {new (options: TextPipelin
  * for the full list of languages and their corresponding codes.
  * 
  * ```javascript
- * let translator = await pipeline('translation', 'Xenova/m2m100_418M');
- * let output = await translator('生活就像一盒巧克力。', {
+ * const translator = await pipeline('translation', 'Xenova/m2m100_418M');
+ * const output = await translator('生活就像一盒巧克力。', {
  *   src_lang: 'zh', // Chinese
  *   tgt_lang: 'en', // English
  * });
@@ -796,8 +794,8 @@ export class SummarizationPipeline extends (/** @type {new (options: TextPipelin
  * for the full list of languages and their corresponding codes.
  * 
  * ```javascript
- * let translator = await pipeline('translation', 'Xenova/mbart-large-50-many-to-many-mmt');
- * let output = await translator('संयुक्त राष्ट्र के प्रमुख का कहना है कि सीरिया में कोई सैन्य समाधान नहीं है', {
+ * const translator = await pipeline('translation', 'Xenova/mbart-large-50-many-to-many-mmt');
+ * const output = await translator('संयुक्त राष्ट्र के प्रमुख का कहना है कि सीरिया में कोई सैन्य समाधान नहीं है', {
  *   src_lang: 'hi_IN', // Hindi
  *   tgt_lang: 'fr_XX', // French
  * });
@@ -840,17 +838,17 @@ export class TranslationPipeline extends (/** @type {new (options: TextPipelineC
  * 
  * **Example:** Text generation with `Xenova/distilgpt2` (default settings).
  * ```javascript
- * let text = 'I enjoy walking with my cute dog,';
- * let generator = await pipeline('text-generation', 'Xenova/distilgpt2');
- * let output = await generator(text);
+ * const generator = await pipeline('text-generation', 'Xenova/distilgpt2');
+ * const text = 'I enjoy walking with my cute dog,';
+ * const output = await generator(text);
  * // [{ generated_text: "I enjoy walking with my cute dog, and I love to play with the other dogs." }]
  * ```
  * 
  * **Example:** Text generation with `Xenova/distilgpt2` (custom settings).
  * ```javascript
- * let text = 'Once upon a time, there was';
- * let generator = await pipeline('text-generation', 'Xenova/distilgpt2');
- * let output = await generator(text, {
+ * const generator = await pipeline('text-generation', 'Xenova/distilgpt2');
+ * const text = 'Once upon a time, there was';
+ * const output = await generator(text, {
  *   temperature: 2,
  *   max_new_tokens: 10,
  *   repetition_penalty: 1.5,
@@ -867,9 +865,9 @@ export class TranslationPipeline extends (/** @type {new (options: TextPipelineC
  * 
  * **Example:** Run code generation with `Xenova/codegen-350M-mono`.
  * ```javascript
- * let text = 'def fib(n):';
- * let generator = await pipeline('text-generation', 'Xenova/codegen-350M-mono');
- * let output = await generator(text, {
+ * const generator = await pipeline('text-generation', 'Xenova/codegen-350M-mono');
+ * const text = 'def fib(n):';
+ * const output = await generator(text, {
  *   max_new_tokens: 44,
  * });
  * // [{
@@ -961,10 +959,10 @@ export class TextGenerationPipeline extends (/** @type {new (options: TextPipeli
  * 
  * **Example:** Zero shot classification with `Xenova/mobilebert-uncased-mnli`.
  * ```javascript
- * let text = 'Last week I upgraded my iOS version and ever since then my phone has been overheating whenever I use your app.';
- * let labels = [ 'mobile', 'billing', 'website', 'account access' ];
- * let classifier = await pipeline('zero-shot-classification', 'Xenova/mobilebert-uncased-mnli');
- * let output = await classifier(text, labels);
+ * const classifier = await pipeline('zero-shot-classification', 'Xenova/mobilebert-uncased-mnli');
+ * const text = 'Last week I upgraded my iOS version and ever since then my phone has been overheating whenever I use your app.';
+ * const labels = [ 'mobile', 'billing', 'website', 'account access' ];
+ * const output = await classifier(text, labels);
  * // {
  * //   sequence: 'Last week I upgraded my iOS version and ever since then my phone has been overheating whenever I use your app.',
  * //   labels: [ 'mobile', 'website', 'billing', 'account access' ],
@@ -974,10 +972,10 @@ export class TextGenerationPipeline extends (/** @type {new (options: TextPipeli
  * 
  * **Example:** Zero shot classification with `Xenova/nli-deberta-v3-xsmall` (multi-label).
  * ```javascript
- * let text = 'I have a problem with my iphone that needs to be resolved asap!';
- * let labels = [ 'urgent', 'not urgent', 'phone', 'tablet', 'computer' ];
- * let classifier = await pipeline('zero-shot-classification', 'Xenova/nli-deberta-v3-xsmall');
- * let output = await classifier(text, labels, { multi_label: true });
+ * const classifier = await pipeline('zero-shot-classification', 'Xenova/nli-deberta-v3-xsmall');
+ * const text = 'I have a problem with my iphone that needs to be resolved asap!';
+ * const labels = [ 'urgent', 'not urgent', 'phone', 'tablet', 'computer' ];
+ * const output = await classifier(text, labels, { multi_label: true });
  * // {
  * //   sequence: 'I have a problem with my iphone that needs to be resolved asap!',
  * //   labels: [ 'urgent', 'phone', 'computer', 'tablet', 'not urgent' ],
@@ -1096,8 +1094,8 @@ export class ZeroShotClassificationPipeline extends (/** @type {new (options: Te
  * 
  * **Example:** Run feature extraction with `bert-base-uncased` (without pooling/normalization).
  * ```javascript
- * let extractor = await pipeline('feature-extraction', 'Xenova/bert-base-uncased', { revision: 'default' });
- * let output = await extractor('This is a simple test.');
+ * const extractor = await pipeline('feature-extraction', 'Xenova/bert-base-uncased', { revision: 'default' });
+ * const output = await extractor('This is a simple test.');
  * // Tensor {
  * //   type: 'float32',
  * //   data: Float32Array [0.05939924716949463, 0.021655935794115067, ...],
@@ -1107,8 +1105,8 @@ export class ZeroShotClassificationPipeline extends (/** @type {new (options: Te
  * 
  * **Example:** Run feature extraction with `bert-base-uncased` (with pooling/normalization).
  * ```javascript
- * let extractor = await pipeline('feature-extraction', 'Xenova/bert-base-uncased', { revision: 'default' });
- * let output = await extractor('This is a simple test.', { pooling: 'mean', normalize: true });
+ * const extractor = await pipeline('feature-extraction', 'Xenova/bert-base-uncased', { revision: 'default' });
+ * const output = await extractor('This is a simple test.', { pooling: 'mean', normalize: true });
  * // Tensor {
  * //   type: 'float32',
  * //   data: Float32Array [0.03373778983950615, -0.010106077417731285, ...],
@@ -1118,8 +1116,8 @@ export class ZeroShotClassificationPipeline extends (/** @type {new (options: Te
  * 
  * **Example:** Calculating embeddings with `sentence-transformers` models.
  * ```javascript
- * let extractor = await pipeline('feature-extraction', 'Xenova/all-MiniLM-L6-v2');
- * let output = await extractor('This is a simple test.', { pooling: 'mean', normalize: true });
+ * const extractor = await pipeline('feature-extraction', 'Xenova/all-MiniLM-L6-v2');
+ * const output = await extractor('This is a simple test.', { pooling: 'mean', normalize: true });
  * // Tensor {
  * //   type: 'float32',
  * //   data: Float32Array [0.09094982594251633, -0.014774246141314507, ...],
@@ -1206,9 +1204,9 @@ export class FeatureExtractionPipeline extends (/** @type {new (options: TextPip
  * 
  * **Example:** Perform audio classification with `Xenova/wav2vec2-large-xlsr-53-gender-recognition-librispeech`.
  * ```javascript
- * let url = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/jfk.wav';
- * let classifier = await pipeline('audio-classification', 'Xenova/wav2vec2-large-xlsr-53-gender-recognition-librispeech');
- * let output = await classifier(url);
+ * const classifier = await pipeline('audio-classification', 'Xenova/wav2vec2-large-xlsr-53-gender-recognition-librispeech');
+ * const url = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/jfk.wav';
+ * const output = await classifier(url);
  * // [
  * //   { label: 'male', score: 0.9981542229652405 },
  * //   { label: 'female', score: 0.001845747814513743 }
@@ -1217,9 +1215,9 @@ export class FeatureExtractionPipeline extends (/** @type {new (options: TextPip
  * 
  * **Example:** Perform audio classification with `Xenova/ast-finetuned-audioset-10-10-0.4593` and return top 4 results.
  * ```javascript
- * let url = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/cat_meow.wav';
- * let classifier = await pipeline('audio-classification', 'Xenova/ast-finetuned-audioset-10-10-0.4593');
- * let output = await classifier(url, { topk: 4 });
+ * const classifier = await pipeline('audio-classification', 'Xenova/ast-finetuned-audioset-10-10-0.4593');
+ * const url = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/cat_meow.wav';
+ * const output = await classifier(url, { topk: 4 });
  * // [
  * //   { label: 'Meow', score: 0.5617874264717102 },
  * //   { label: 'Cat', score: 0.22365376353263855 },
@@ -1299,10 +1297,10 @@ export class AudioClassificationPipeline extends (/** @type {new (options: Audio
  * 
  * **Example**: Perform zero-shot audio classification with `Xenova/clap-htsat-unfused`.
  * ```javascript
- * let classifier = await pipeline('zero-shot-audio-classification', 'Xenova/clap-htsat-unfused');
- * let audio = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/dog_barking.wav';
- * let candidate_labels = ['dog', 'vaccum cleaner'];
- * let scores = await classifier(audio, candidate_labels);
+ * const classifier = await pipeline('zero-shot-audio-classification', 'Xenova/clap-htsat-unfused');
+ * const audio = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/dog_barking.wav';
+ * const candidate_labels = ['dog', 'vaccum cleaner'];
+ * const scores = await classifier(audio, candidate_labels);
  * // [
  * //   { score: 0.9993992447853088, label: 'dog' },
  * //   { score: 0.0006007603369653225, label: 'vaccum cleaner' }
@@ -1409,17 +1407,17 @@ export class ZeroShotAudioClassificationPipeline extends (/** @type {new (option
  *
  * **Example:** Transcribe English.
  * ```javascript
- * let url = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/jfk.wav';
- * let transcriber = await pipeline('automatic-speech-recognition', 'Xenova/whisper-tiny.en');
- * let output = await transcriber(url);
+ * const transcriber = await pipeline('automatic-speech-recognition', 'Xenova/whisper-tiny.en');
+ * const url = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/jfk.wav';
+ * const output = await transcriber(url);
  * // { text: " And so my fellow Americans ask not what your country can do for you, ask what you can do for your country." }
  * ```
  * 
  * **Example:** Transcribe English w/ timestamps.
  * ```javascript
- * let url = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/jfk.wav';
- * let transcriber = await pipeline('automatic-speech-recognition', 'Xenova/whisper-tiny.en');
- * let output = await transcriber(url, { return_timestamps: true });
+ * const transcriber = await pipeline('automatic-speech-recognition', 'Xenova/whisper-tiny.en');
+ * const url = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/jfk.wav';
+ * const output = await transcriber(url, { return_timestamps: true });
  * // {
  * //   text: " And so my fellow Americans ask not what your country can do for you, ask what you can do for your country."
  * //   chunks: [
@@ -1431,9 +1429,9 @@ export class ZeroShotAudioClassificationPipeline extends (/** @type {new (option
  * 
  * **Example:** Transcribe English w/ word-level timestamps.
  * ```javascript
- * let url = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/jfk.wav';
- * let transcriber = await pipeline('automatic-speech-recognition', 'Xenova/whisper-tiny.en');
- * let output = await transcriber(url, { return_timestamps: 'word' });
+ * const transcriber = await pipeline('automatic-speech-recognition', 'Xenova/whisper-tiny.en');
+ * const url = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/jfk.wav';
+ * const output = await transcriber(url, { return_timestamps: 'word' });
  * // {
  * //   "text": " And so my fellow Americans ask not what your country can do for you ask what you can do for your country.",
  * //   "chunks": [
@@ -1450,25 +1448,25 @@ export class ZeroShotAudioClassificationPipeline extends (/** @type {new (option
  * 
  * **Example:** Transcribe French.
  * ```javascript
- * let url = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/french-audio.mp3';
- * let transcriber = await pipeline('automatic-speech-recognition', 'Xenova/whisper-small');
- * let output = await transcriber(url, { language: 'french', task: 'transcribe' });
+ * const transcriber = await pipeline('automatic-speech-recognition', 'Xenova/whisper-small');
+ * const url = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/french-audio.mp3';
+ * const output = await transcriber(url, { language: 'french', task: 'transcribe' });
  * // { text: " J'adore, j'aime, je n'aime pas, je déteste." }
  * ```
  * 
  * **Example:** Translate French to English.
  * ```javascript
- * let url = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/french-audio.mp3';
- * let transcriber = await pipeline('automatic-speech-recognition', 'Xenova/whisper-small');
- * let output = await transcriber(url, { language: 'french', task: 'translate' });
+ * const transcriber = await pipeline('automatic-speech-recognition', 'Xenova/whisper-small');
+ * const url = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/french-audio.mp3';
+ * const output = await transcriber(url, { language: 'french', task: 'translate' });
  * // { text: " I love, I like, I don't like, I hate." }
  * ```
  * 
  * **Example:** Transcribe/translate audio longer than 30 seconds.
  * ```javascript
- * let url = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/ted_60.wav';
- * let transcriber = await pipeline('automatic-speech-recognition', 'Xenova/whisper-tiny.en');
- * let output = await transcriber(url, { chunk_length_s: 30, stride_length_s: 5 });
+ * const transcriber = await pipeline('automatic-speech-recognition', 'Xenova/whisper-tiny.en');
+ * const url = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/ted_60.wav';
+ * const output = await transcriber(url, { chunk_length_s: 30, stride_length_s: 5 });
  * // { text: " So in college, I was a government major, which means [...] So I'd start off light and I'd bump it up" }
  * ```
  */
@@ -1677,17 +1675,17 @@ export class AutomaticSpeechRecognitionPipeline extends (/** @type {new (options
  * 
  * **Example:** Generate a caption for an image w/ `Xenova/vit-gpt2-image-captioning`.
  * ```javascript
- * let url = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/cats.jpg';
- * let captioner = await pipeline('image-to-text', 'Xenova/vit-gpt2-image-captioning');
- * let output = await captioner(url);
+ * const captioner = await pipeline('image-to-text', 'Xenova/vit-gpt2-image-captioning');
+ * const url = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/cats.jpg';
+ * const output = await captioner(url);
  * // [{ generated_text: 'a cat laying on a couch with another cat' }]
  * ```
  * 
  * **Example:** Optical Character Recognition (OCR) w/ `Xenova/trocr-small-handwritten`.
  * ```javascript
- * let url = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/handwriting.jpg';
- * let captioner = await pipeline('image-to-text', 'Xenova/trocr-small-handwritten');
- * let output = await captioner(url);
+ * const captioner = await pipeline('image-to-text', 'Xenova/trocr-small-handwritten');
+ * const url = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/handwriting.jpg';
+ * const output = await captioner(url);
  * // [{ generated_text: 'Mr. Brown commented icily.' }]
  * ```
  */
@@ -1743,9 +1741,9 @@ export class ImageToTextPipeline extends (/** @type {new (options: TextImagePipe
  * 
  * **Example:** Classify an image.
  * ```javascript
- * let classifier = await pipeline('image-classification', 'Xenova/vit-base-patch16-224');
- * let url = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/tiger.jpg';
- * let output = await classifier(url);
+ * const classifier = await pipeline('image-classification', 'Xenova/vit-base-patch16-224');
+ * const url = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/tiger.jpg';
+ * const output = await classifier(url);
  * // [
  * //   { label: 'tiger, Panthera tigris', score: 0.632695734500885 },
  * // ]
@@ -1753,9 +1751,9 @@ export class ImageToTextPipeline extends (/** @type {new (options: TextImagePipe
  * 
  * **Example:** Classify an image and return top `n` classes.
  * ```javascript
- * let classifier = await pipeline('image-classification', 'Xenova/vit-base-patch16-224');
- * let url = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/tiger.jpg';
- * let output = await classifier(url, { topk: 3 });
+ * const classifier = await pipeline('image-classification', 'Xenova/vit-base-patch16-224');
+ * const url = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/tiger.jpg';
+ * const output = await classifier(url, { topk: 3 });
  * // [
  * //   { label: 'tiger, Panthera tigris', score: 0.632695734500885 },
  * //   { label: 'tiger cat', score: 0.3634825646877289 },
@@ -1765,9 +1763,9 @@ export class ImageToTextPipeline extends (/** @type {new (options: TextImagePipe
  * 
  * **Example:** Classify an image and return all classes.
  * ```javascript
- * let classifier = await pipeline('image-classification', 'Xenova/vit-base-patch16-224');
- * let url = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/tiger.jpg';
- * let output = await classifier(url, { topk: 0 });
+ * const classifier = await pipeline('image-classification', 'Xenova/vit-base-patch16-224');
+ * const url = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/tiger.jpg';
+ * const output = await classifier(url, { topk: 0 });
  * // [
  * //   { label: 'tiger, Panthera tigris', score: 0.632695734500885 },
  * //   { label: 'tiger cat', score: 0.3634825646877289 },
@@ -1844,9 +1842,9 @@ export class ImageClassificationPipeline extends (/** @type {new (options: Image
  * 
  * **Example:** Perform image segmentation with `Xenova/detr-resnet-50-panoptic`.
  * ```javascript
- * let url = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/cats.jpg';
- * let segmenter = await pipeline('image-segmentation', 'Xenova/detr-resnet-50-panoptic');
- * let output = await segmenter(url);
+ * const segmenter = await pipeline('image-segmentation', 'Xenova/detr-resnet-50-panoptic');
+ * const url = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/cats.jpg';
+ * const output = await segmenter(url);
  * // [
  * //   { label: 'remote', score: 0.9984649419784546, mask: RawImage { ... } },
  * //   { label: 'cat', score: 0.9994316101074219, mask: RawImage { ... } }
@@ -1985,9 +1983,9 @@ export class ImageSegmentationPipeline extends (/** @type {new (options: ImagePi
  * 
  * **Example:** Zero shot image classification w/ `Xenova/clip-vit-base-patch32`.
  * ```javascript
- * let classifier = await pipeline('zero-shot-image-classification', 'Xenova/clip-vit-base-patch32');
- * let url = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/tiger.jpg';
- * let output = await classifier(url, ['tiger', 'horse', 'dog']);
+ * const classifier = await pipeline('zero-shot-image-classification', 'Xenova/clip-vit-base-patch32');
+ * const url = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/tiger.jpg';
+ * const output = await classifier(url, ['tiger', 'horse', 'dog']);
  * // [
  * //   { score: 0.9993917942047119, label: 'tiger' },
  * //   { score: 0.0003519294841680676, label: 'horse' },
@@ -2074,12 +2072,11 @@ export class ZeroShotImageClassificationPipeline extends (/** @type {new (option
  * Object detection pipeline using any `AutoModelForObjectDetection`.
  * This pipeline predicts bounding boxes of objects and their classes.
  * 
- * **Example:** Run object-detection with `facebook/detr-resnet-50`.
+ * **Example:** Run object-detection with `Xenova/detr-resnet-50`.
  * ```javascript
- * let img = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/cats.jpg';
- * 
- * let detector = await pipeline('object-detection', 'Xenova/detr-resnet-50');
- * let output = await detector(img, { threshold: 0.9 });
+ * const detector = await pipeline('object-detection', 'Xenova/detr-resnet-50');
+ * const img = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/cats.jpg';
+ * const output = await detector(img, { threshold: 0.9 });
  * // [{
  * //   score: 0.9976370930671692,
  * //   label: "remote",
@@ -2167,10 +2164,10 @@ export class ObjectDetectionPipeline extends (/** @type {new (options: ImagePipe
  * 
  * **Example:** Zero-shot object detection w/ `Xenova/owlvit-base-patch32`.
  * ```javascript
- * let url = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/astronaut.png';
- * let candidate_labels = ['human face', 'rocket', 'helmet', 'american flag'];
- * let detector = await pipeline('zero-shot-object-detection', 'Xenova/owlvit-base-patch32');
- * let output = await detector(url, candidate_labels);
+ * const detector = await pipeline('zero-shot-object-detection', 'Xenova/owlvit-base-patch32');
+ * const url = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/astronaut.png';
+ * const candidate_labels = ['human face', 'rocket', 'helmet', 'american flag'];
+ * const output = await detector(url, candidate_labels);
  * // [
  * //   {
  * //     score: 0.24392342567443848,
@@ -2197,10 +2194,10 @@ export class ObjectDetectionPipeline extends (/** @type {new (options: ImagePipe
  * 
  * **Example:** Zero-shot object detection w/ `Xenova/owlvit-base-patch32` (returning top 4 matches and setting a threshold).
  * ```javascript
- * let url = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/beach.png';
- * let candidate_labels = ['hat', 'book', 'sunglasses', 'camera'];
- * let detector = await pipeline('zero-shot-object-detection', 'Xenova/owlvit-base-patch32');
- * let output = await detector(url, candidate_labels, { topk: 4, threshold: 0.05 });
+ * const detector = await pipeline('zero-shot-object-detection', 'Xenova/owlvit-base-patch32');
+ * const url = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/beach.png';
+ * const candidate_labels = ['hat', 'book', 'sunglasses', 'camera'];
+ * const output = await detector(url, candidate_labels, { topk: 4, threshold: 0.05 });
  * // [
  * //   {
  * //     score: 0.1606510728597641,
@@ -2303,11 +2300,10 @@ export class ZeroShotObjectDetectionPipeline extends (/** @type {new (options: T
  * 
  * **Example:** Answer questions about a document with `Xenova/donut-base-finetuned-docvqa`.
  * ```javascript
- * let image = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/invoice.png';
- * let question = 'What is the invoice number?';
- * 
- * let qa_pipeline = await pipeline('document-question-answering', 'Xenova/donut-base-finetuned-docvqa');
- * let output = await qa_pipeline(image, question);
+ * const qa_pipeline = await pipeline('document-question-answering', 'Xenova/donut-base-finetuned-docvqa');
+ * const image = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/invoice.png';
+ * const question = 'What is the invoice number?';
+ * const output = await qa_pipeline(image, question);
  * // [{ answer: 'us-001' }]
  * ```
  */
@@ -2388,9 +2384,9 @@ export class DocumentQuestionAnsweringPipeline extends (/** @type {new (options:
  * 
  * **Example:** Generate audio from text with `Xenova/speecht5_tts`.
  * ```javascript
- * let speaker_embeddings = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/speaker_embeddings.bin';
- * let synthesizer = await pipeline('text-to-speech', 'Xenova/speecht5_tts', { quantized: false });
- * let out = await synthesizer('Hello, my dog is cute', { speaker_embeddings });
+ * const synthesizer = await pipeline('text-to-speech', 'Xenova/speecht5_tts', { quantized: false });
+ * const speaker_embeddings = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/speaker_embeddings.bin';
+ * const out = await synthesizer('Hello, my dog is cute', { speaker_embeddings });
  * // {
  * //   audio: Float32Array(26112) [-0.00005657337896991521, 0.00020583874720614403, ...],
  * //   sampling_rate: 16000
@@ -2402,15 +2398,15 @@ export class DocumentQuestionAnsweringPipeline extends (/** @type {new (options:
  * import wavefile from 'wavefile';
  * import fs from 'fs';
  * 
- * let wav = new wavefile.WaveFile();
+ * const wav = new wavefile.WaveFile();
  * wav.fromScratch(1, out.sampling_rate, '32f', out.audio);
  * fs.writeFileSync('out.wav', wav.toBuffer());
  * ```
  * 
  * **Example:** Multilingual speech generation with `Xenova/mms-tts-fra`. See [here](https://huggingface.co/models?pipeline_tag=text-to-speech&other=vits&sort=trending) for the full list of available languages (1107).
  * ```javascript
- * let synthesizer = await pipeline('text-to-speech', 'Xenova/mms-tts-fra');
- * let out = await synthesizer('Bonjour');
+ * const synthesizer = await pipeline('text-to-speech', 'Xenova/mms-tts-fra');
+ * const out = await synthesizer('Bonjour');
  * // {
  * //   audio: Float32Array(23808) [-0.00037693005288019776, 0.0003325853613205254, ...],
  * //   sampling_rate: 16000
@@ -2521,9 +2517,9 @@ export class TextToAudioPipeline extends (/** @type {new (options: TextToAudioPi
  * 
  * **Example:** Super-resolution w/ `Xenova/swin2SR-classical-sr-x2-64`
  * ```javascript
- * let url = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/butterfly.jpg';
- * let upscaler = await pipeline('image-to-image', 'Xenova/swin2SR-classical-sr-x2-64');
- * let output = await upscaler(url);
+ * const upscaler = await pipeline('image-to-image', 'Xenova/swin2SR-classical-sr-x2-64');
+ * const url = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/butterfly.jpg';
+ * const output = await upscaler(url);
  * // RawImage {
  * //   data: Uint8Array(786432) [ 41, 31, 24,  43, ... ],
  * //   width: 512,
@@ -2575,9 +2571,9 @@ export class ImageToImagePipeline extends (/** @type {new (options: ImagePipelin
  * 
  * **Example:** Depth estimation w/ `Xenova/dpt-hybrid-midas`
  * ```javascript
- * let url = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/cats.jpg';
- * let depth_estimator = await pipeline('depth-estimation', 'Xenova/dpt-hybrid-midas');
- * let out = await depth_estimator(url);
+ * const depth_estimator = await pipeline('depth-estimation', 'Xenova/dpt-hybrid-midas');
+ * const url = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/cats.jpg';
+ * const out = await depth_estimator(url);
  * // {
  * //   predicted_depth: Tensor {
  * //     dims: [ 384, 384 ],

--- a/src/pipelines.js
+++ b/src/pipelines.js
@@ -1622,7 +1622,7 @@ export class ImageClassificationPipeline extends Pipeline {
  */
 
 /** @type {new (_) => ImageSegmentationPipelineCallback} */
-export const ImageSegmentationPipelineProxy = /** @type {any} */ (class extends Pipeline { });
+const ImageSegmentationPipelineProxy = /** @type {any} */ (class extends Pipeline { });
 
 /**
  * Image segmentation pipeline using any `AutoModelForXXXSegmentation`.
@@ -1639,7 +1639,7 @@ export const ImageSegmentationPipelineProxy = /** @type {any} */ (class extends 
  * // ]
  * ```
  */
-class ImageSegmentationPipeline extends ImageSegmentationPipelineProxy {
+export class ImageSegmentationPipeline extends ImageSegmentationPipelineProxy {
     /**
      * Create a new ImageSegmentationPipeline.
      * @param {Object} options An object containing the following properties:

--- a/src/pipelines.js
+++ b/src/pipelines.js
@@ -173,7 +173,7 @@ export class Pipeline extends Callable {
  * // ]
  * ```
  */
-export class TextClassificationPipeline extends (/** @type {new (_) => TextClassificationPipelineCallback} */ (/** @type {any} */ (class extends Pipeline { }))) {
+export class TextClassificationPipeline extends (/** @type {new (_) => TextClassificationPipelineCallback} */ (/** @type {any} */ Pipeline)) {
     /** @type {TextClassificationPipelineCallback} */
     async _call(texts, {
         topk = 1
@@ -1647,7 +1647,7 @@ export class ImageClassificationPipeline extends Pipeline {
  * // ]
  * ```
  */
-export class ImageSegmentationPipeline extends (/** @type {new (_) => ImageSegmentationPipelineCallback} */ (/** @type {any} */ (class extends Pipeline { }))) {
+export class ImageSegmentationPipeline extends (/** @type {new (_) => ImageSegmentationPipelineCallback} */ (/** @type {any} */ Pipeline)) {
     /**
      * Create a new ImageSegmentationPipeline.
      * @param {Object} options An object containing the following properties:

--- a/src/pipelines.js
+++ b/src/pipelines.js
@@ -430,6 +430,7 @@ export class QuestionAnsweringPipeline extends (/** @type {new (_) => QuestionAn
  * @param {Object} options An optional object containing the following properties:
  * @param {number} [options.topk=5] When passed, overrides the number of predictions to return.
  * @returns {Promise<FillMaskOutput|FillMaskOutput[]>} A promise that resolves to an array or object containing the predicted tokens and scores.
+ * @throws {Error} When the mask token is not found in the input text.
  */
 
 /**
@@ -524,7 +525,6 @@ export class Text2TextGenerationPipeline extends Pipeline {
      * @returns {Promise<any>} An array of objects containing the score, predicted token, predicted token string,
      * and the sequence with the predicted token filled in, or an array of such arrays (one for each input text).
      * If only one input text is given, the output will be an array of objects.
-     * @throws {Error} When the mask token is not found in the input text.
      */
     async _call(texts, generate_kwargs = {}) {
         if (!Array.isArray(texts)) {

--- a/src/pipelines.js
+++ b/src/pipelines.js
@@ -1833,7 +1833,7 @@ export class ImageClassificationPipeline extends (/** @type {new (options: Image
  * // ]
  * ```
  */
-export class ImageSegmentationPipeline extends (/** @type {new (_) => ImageSegmentationPipelineCallback} */ (/** @type {any} */ Pipeline)) {
+export class ImageSegmentationPipeline extends (/** @type {new (options: ImagePipelineConstructorArgs) => ImageSegmentationPipelineCallback} */ (/** @type {any} */ Pipeline)) {
     /**
      * Create a new ImageSegmentationPipeline.
      * @param {ImagePipelineConstructorArgs} options An object used to instantiate the pipeline.

--- a/src/pipelines.js
+++ b/src/pipelines.js
@@ -151,6 +151,37 @@ export class Pipeline extends Callable {
 }
 
 /**
+ * @typedef {Object} ModelTokenizerConstructorArgs
+ * @property {string} task The task of the pipeline. Useful for specifying subtasks.
+ * @property {PreTrainedModel} model The model to use.
+ * @property {PreTrainedTokenizer} tokenizer The tokenizer to use.
+ * 
+ * @typedef {ModelTokenizerConstructorArgs} TextPipelineConstructorArgs An object used to instantiate a text-based pipeline.
+ */
+
+/**
+ * @typedef {Object} ModelProcessorConstructorArgs
+ * @property {string} task The task of the pipeline. Useful for specifying subtasks.
+ * @property {PreTrainedModel} model The model to use.
+ * @property {Processor} processor The processor to use.
+ * 
+ * @typedef {ModelProcessorConstructorArgs} AudioPipelineConstructorArgs An object used to instantiate an audio-based pipeline.
+ * @typedef {ModelProcessorConstructorArgs} ImagePipelineConstructorArgs An object used to instantiate an image-based pipeline.
+ */
+
+
+/**
+ * @typedef {Object} ModelTokenizerProcessorConstructorArgs
+ * @property {string} task The task of the pipeline. Useful for specifying subtasks.
+ * @property {PreTrainedModel} model The model to use.
+ * @property {PreTrainedTokenizer} tokenizer The tokenizer to use.
+ * @property {Processor} processor The processor to use.
+ * 
+ * @typedef {ModelTokenizerProcessorConstructorArgs} TextAudioPipelineConstructorArgs An object used to instantiate a text- and audio-based pipeline.
+ * @typedef {ModelTokenizerProcessorConstructorArgs} TextImagePipelineConstructorArgs An object used to instantiate a text- and image-based pipeline.
+ */
+
+/**
  * @typedef {Object} TextClassificationSingle
  * @property {string} label The label predicted.
  * @property {number} score The corresponding probability.
@@ -200,7 +231,16 @@ export class Pipeline extends Callable {
  * // ]
  * ```
  */
-export class TextClassificationPipeline extends (/** @type {new (_) => TextClassificationPipelineCallback} */ (/** @type {any} */ Pipeline)) {
+export class TextClassificationPipeline extends (/** @type {new (options: TextPipelineConstructorArgs) => TextClassificationPipelineCallback} */ (/** @type {any} */ Pipeline)) {
+
+    /**
+     * Create a new TextClassificationPipeline.
+     * @param {TextPipelineConstructorArgs} options An object used to instantiate the pipeline.
+     */
+    constructor(options) {
+        super(options);
+    }
+
     /** @type {TextClassificationPipelineCallback} */
     async _call(texts, {
         topk = 1
@@ -291,7 +331,16 @@ export class TextClassificationPipeline extends (/** @type {new (_) => TextClass
  * // ]
  * ```
  */
-export class TokenClassificationPipeline extends (/** @type {new (_) => TokenClassificationPipelineCallback} */ (/** @type {any} */ Pipeline)) {
+export class TokenClassificationPipeline extends (/** @type {new (options: TextPipelineConstructorArgs) => TokenClassificationPipelineCallback} */ (/** @type {any} */ Pipeline)) {
+
+    /**
+     * Create a new TokenClassificationPipeline.
+     * @param {TextPipelineConstructorArgs} options An object used to instantiate the pipeline.
+     */
+    constructor(options) {
+        super(options);
+    }
+
     /** @type {TokenClassificationPipelineCallback} */
     async _call(texts, {
         ignore_labels = ['O'],
@@ -387,7 +436,16 @@ export class TokenClassificationPipeline extends (/** @type {new (_) => TokenCla
  * // }
  * ```
  */
-export class QuestionAnsweringPipeline extends (/** @type {new (_) => QuestionAnsweringPipelineCallback} */ (/** @type {any} */ Pipeline)) {
+export class QuestionAnsweringPipeline extends (/** @type {new (options: TextPipelineConstructorArgs) => QuestionAnsweringPipelineCallback} */ (/** @type {any} */ Pipeline)) {
+
+    /**
+     * Create a new QuestionAnsweringPipeline.
+     * @param {TextPipelineConstructorArgs} options An object used to instantiate the pipeline.
+     */
+    constructor(options) {
+        super(options);
+    }
+
     /** @type {QuestionAnsweringPipelineCallback} */
     async _call(question, context, {
         topk = 1
@@ -485,7 +543,16 @@ export class QuestionAnsweringPipeline extends (/** @type {new (_) => QuestionAn
  * // [{ token_str: 'spiral', score: 0.6299987435340881, token: 14061, sequence: 'The Milky Way is a spiral galaxy.' }]
  * ```
  */
-export class FillMaskPipeline extends (/** @type {new (_) => FillMaskPipelineCallback} */ (/** @type {any} */ Pipeline)) {
+export class FillMaskPipeline extends (/** @type {new (options: TextPipelineConstructorArgs) => FillMaskPipelineCallback} */ (/** @type {any} */ Pipeline)) {
+
+    /**
+     * Create a new FillMaskPipeline.
+     * @param {TextPipelineConstructorArgs} options An object used to instantiate the pipeline.
+     */
+    constructor(options) {
+        super(options);
+    }
+
     /** @type {FillMaskPipelineCallback} */
     async _call(texts, {
         topk = 5
@@ -555,9 +622,17 @@ export class FillMaskPipeline extends (/** @type {new (_) => FillMaskPipelineCal
  * // [{ generated_text: "To become more healthy, you can: 1. Eat a balanced diet with plenty of fruits, vegetables, whole grains, lean proteins, and healthy fats. 2. Stay hydrated by drinking plenty of water. 3. Get enough sleep and manage stress levels. 4. Avoid smoking and excessive alcohol consumption. 5. Regularly exercise and maintain a healthy weight. 6. Practice good hygiene and sanitation. 7. Seek medical attention if you experience any health issues." }]
  * ```
  */
-export class Text2TextGenerationPipeline extends (/** @type {new (_) => Text2TextGenerationPipelineCallback} */ (/** @type {any} */ Pipeline)) {
+export class Text2TextGenerationPipeline extends (/** @type {new (options: TextPipelineConstructorArgs) => Text2TextGenerationPipelineCallback} */ (/** @type {any} */ Pipeline)) {
     /** @type {'generated_text'} */
     _key = 'generated_text';
+
+    /**
+     * Create a new Text2TextGenerationPipeline.
+     * @param {TextPipelineConstructorArgs} options An object used to instantiate the pipeline.
+     */
+    constructor(options) {
+        super(options);
+    }
 
     /** @type {Text2TextGenerationPipelineCallback} */
     async _call(texts, generate_kwargs = {}) {
@@ -639,9 +714,17 @@ export class Text2TextGenerationPipeline extends (/** @type {new (_) => Text2Tex
  * // [{ summary_text: ' The Eiffel Tower is about the same height as an 81-storey building and the tallest structure in Paris. It is the second tallest free-standing structure in France after the Millau Viaduct.' }]
  * ```
  */
-export class SummarizationPipeline extends (/** @type {new (_) => SummarizationGenerationPipelineCallback} */ (/** @type {any} */ (Text2TextGenerationPipeline))) {
+export class SummarizationPipeline extends (/** @type {new (options: TextPipelineConstructorArgs) => SummarizationGenerationPipelineCallback} */ (/** @type {any} */ (Text2TextGenerationPipeline))) {
     /** @type {'summary_text'} */
     _key = 'summary_text';
+
+    /**
+     * Create a new SummarizationPipeline.
+     * @param {TextPipelineConstructorArgs} options An object used to instantiate the pipeline.
+     */
+    constructor(options) {
+        super(options);
+    }
 }
 
 
@@ -701,9 +784,17 @@ export class SummarizationPipeline extends (/** @type {new (_) => SummarizationG
  * // [{ translation_text: 'Le chef des Nations affirme qu 'il n 'y a military solution in Syria.' }]
  * ```
  */
-export class TranslationPipeline extends (/** @type {new (_) => TranslationGenerationPipelineCallback} */ (/** @type {any} */ (Text2TextGenerationPipeline))) {
+export class TranslationPipeline extends (/** @type {new (options: TextPipelineConstructorArgs) => TranslationGenerationPipelineCallback} */ (/** @type {any} */ (Text2TextGenerationPipeline))) {
     /** @type {'translation_text'} */
     _key = 'translation_text';
+
+    /**
+     * Create a new TranslationPipeline.
+     * @param {TextPipelineConstructorArgs} options An object used to instantiate the pipeline.
+     */
+    constructor(options) {
+        super(options);
+    }
 }
 
 
@@ -772,7 +863,16 @@ export class TranslationPipeline extends (/** @type {new (_) => TranslationGener
  * // }]
  * ```
  */
-export class TextGenerationPipeline extends (/** @type {new (_) => TextGenerationPipelineCallback} */ (/** @type {any} */ Pipeline)) {
+export class TextGenerationPipeline extends (/** @type {new (options: TextPipelineConstructorArgs) => TextGenerationPipelineCallback} */ (/** @type {any} */ Pipeline)) {
+
+    /**
+     * Create a new TextGenerationPipeline.
+     * @param {TextPipelineConstructorArgs} options An object used to instantiate the pipeline.
+     */
+    constructor(options) {
+        super(options);
+    }
+
     /** @type {TextGenerationPipelineCallback} */
     async _call(texts, generate_kwargs = {}) {
         const self = /** @type {TextGenerationPipeline & Pipeline} */ (/** @type {any} */ (this));
@@ -865,13 +965,10 @@ export class TextGenerationPipeline extends (/** @type {new (_) => TextGeneratio
  * // }
  * ```
  */
-export class ZeroShotClassificationPipeline extends (/** @type {new (_) => ZeroShotClassificationPipelineCallback} */ (/** @type {any} */ Pipeline)) {
+export class ZeroShotClassificationPipeline extends (/** @type {new (options: TextPipelineConstructorArgs) => ZeroShotClassificationPipelineCallback} */ (/** @type {any} */ Pipeline)) {
     /**
      * Create a new ZeroShotClassificationPipeline.
-     * @param {Object} options An object containing the following properties:
-     * @param {string} [options.task] The task of the pipeline. Useful for specifying subtasks.
-     * @param {PreTrainedModel} [options.model] The model to use.
-     * @param {PreTrainedTokenizer} [options.tokenizer] The tokenizer to use.
+     * @param {TextPipelineConstructorArgs} options An object used to instantiate the pipeline.
      */
     constructor(options) {
         super(options);
@@ -1010,7 +1107,14 @@ export class ZeroShotClassificationPipeline extends (/** @type {new (_) => ZeroS
  * // }
  * ```
  */
-export class FeatureExtractionPipeline extends (/** @type {new (_) => FeatureExtractionPipelineCallback} */ (/** @type {any} */ Pipeline)) {
+export class FeatureExtractionPipeline extends (/** @type {new (options: TextPipelineConstructorArgs) => FeatureExtractionPipelineCallback} */ (/** @type {any} */ Pipeline)) {
+    /**
+     * Create a new FeatureExtractionPipeline.
+     * @param {TextPipelineConstructorArgs} options An object used to instantiate the pipeline.
+     */
+    constructor(options) {
+        super(options);
+    }
 
     /** @type {FeatureExtractionPipelineCallback} */
     async _call(texts, {
@@ -1104,13 +1208,11 @@ export class FeatureExtractionPipeline extends (/** @type {new (_) => FeatureExt
  * // ]
  * ```
  */
-export class AudioClassificationPipeline extends (/** @type {new (_) => AudioClassificationPipelineCallback} */ (/** @type {any} */ Pipeline)) {
+export class AudioClassificationPipeline extends (/** @type {new (options: AudioPipelineConstructorArgs) => AudioClassificationPipelineCallback} */ (/** @type {any} */ Pipeline)) {
+
     /**
      * Create a new AudioClassificationPipeline.
-     * @param {Object} options An object containing the following properties:
-     * @param {string} [options.task] The task of the pipeline. Useful for specifying subtasks.
-     * @param {PreTrainedModel} [options.model] The model to use.
-     * @param {Processor} [options.processor] The processor to use.
+     * @param {AudioPipelineConstructorArgs} options An object used to instantiate the pipeline.
      */
     constructor(options) {
         super(options);
@@ -1187,15 +1289,11 @@ export class AudioClassificationPipeline extends (/** @type {new (_) => AudioCla
  * // ]
  * ```
  */
-export class ZeroShotAudioClassificationPipeline extends (/** @type {new (_) => ZeroShotAudioClassificationPipelineCallback} */ (/** @type {any} */ Pipeline)) {
+export class ZeroShotAudioClassificationPipeline extends (/** @type {new (options: TextAudioPipelineConstructorArgs) => ZeroShotAudioClassificationPipelineCallback} */ (/** @type {any} */ Pipeline)) {
 
     /**
      * Create a new ZeroShotAudioClassificationPipeline.
-     * @param {Object} options An object containing the following properties:
-     * @param {string} [options.task] The task of the pipeline. Useful for specifying subtasks.
-     * @param {PreTrainedModel} [options.model] The model to use.
-     * @param {PreTrainedTokenizer} [options.tokenizer] The tokenizer to use.
-     * @param {Processor} [options.processor] The processor to use.
+     * @param {TextAudioPipelineConstructorArgs} options An object used to instantiate the pipeline.
      */
     constructor(options) {
         super(options);
@@ -1355,15 +1453,11 @@ export class ZeroShotAudioClassificationPipeline extends (/** @type {new (_) => 
  * // { text: " So in college, I was a government major, which means [...] So I'd start off light and I'd bump it up" }
  * ```
  */
-export class AutomaticSpeechRecognitionPipeline extends (/** @type {new (_) => AutomaticSpeechRecognitionPipelineCallback} */ (/** @type {any} */ Pipeline)) {
+export class AutomaticSpeechRecognitionPipeline extends (/** @type {new (options: TextAudioPipelineConstructorArgs) => AutomaticSpeechRecognitionPipelineCallback} */ (/** @type {any} */ Pipeline)) {
 
     /**
      * Create a new AutomaticSpeechRecognitionPipeline.
-     * @param {Object} options An object containing the following properties:
-     * @param {string} [options.task] The task of the pipeline. Useful for specifying subtasks.
-     * @param {PreTrainedModel} [options.model] The model to use.
-     * @param {PreTrainedTokenizer} [options.tokenizer] The tokenizer to use.
-     * @param {Processor} [options.processor] The processor to use.
+     * @param {TextAudioPipelineConstructorArgs} options An object used to instantiate the pipeline.
      */
     constructor(options) {
         super(options);
@@ -1570,11 +1664,7 @@ export class AutomaticSpeechRecognitionPipeline extends (/** @type {new (_) => A
 export class ImageToTextPipeline extends Pipeline {
     /**
      * Create a new ImageToTextPipeline.
-     * @param {Object} options An object containing the following properties:
-     * @param {string} [options.task] The task of the pipeline. Useful for specifying subtasks.
-     * @param {PreTrainedModel} [options.model] The model to use.
-     * @param {PreTrainedTokenizer} [options.tokenizer] The tokenizer to use.
-     * @param {Processor} [options.processor] The processor to use.
+     * @param {TextImagePipelineConstructorArgs} options An object used to instantiate the pipeline.
      */
     constructor(options) {
         super(options);
@@ -1651,10 +1741,7 @@ export class ImageToTextPipeline extends Pipeline {
 export class ImageClassificationPipeline extends Pipeline {
     /**
      * Create a new ImageClassificationPipeline.
-     * @param {Object} options An object containing the following properties:
-     * @param {string} [options.task] The task of the pipeline. Useful for specifying subtasks.
-     * @param {PreTrainedModel} [options.model] The model to use.
-     * @param {Processor} [options.processor] The processor to use.
+     * @param {ImagePipelineConstructorArgs} options An object used to instantiate the pipeline.
      */
     constructor(options) {
         super(options);
@@ -1735,10 +1822,7 @@ export class ImageClassificationPipeline extends Pipeline {
 export class ImageSegmentationPipeline extends (/** @type {new (_) => ImageSegmentationPipelineCallback} */ (/** @type {any} */ Pipeline)) {
     /**
      * Create a new ImageSegmentationPipeline.
-     * @param {Object} options An object containing the following properties:
-     * @param {string} [options.task] The task of the pipeline. Useful for specifying subtasks.
-     * @param {PreTrainedModel} [options.model] The model to use.
-     * @param {Processor} [options.processor] The processor to use.
+     * @param {ImagePipelineConstructorArgs} options An object used to instantiate the pipeline.
      */
     constructor(options) {
         super(options);
@@ -1866,11 +1950,7 @@ export class ZeroShotImageClassificationPipeline extends Pipeline {
 
     /**
      * Create a new ZeroShotImageClassificationPipeline.
-     * @param {Object} options An object containing the following properties:
-     * @param {string} [options.task] The task of the pipeline. Useful for specifying subtasks.
-     * @param {PreTrainedModel} [options.model] The model to use.
-     * @param {PreTrainedTokenizer} [options.tokenizer] The tokenizer to use.
-     * @param {Processor} [options.processor] The processor to use.
+     * @param {TextImagePipelineConstructorArgs} options An object used to instantiate the pipeline.
      */
     constructor(options) {
         super(options);
@@ -1956,10 +2036,7 @@ export class ZeroShotImageClassificationPipeline extends Pipeline {
 export class ObjectDetectionPipeline extends Pipeline {
     /**
      * Create a new ObjectDetectionPipeline.
-     * @param {Object} options An object containing the following properties:
-     * @param {string} [options.task] The task of the pipeline. Useful for specifying subtasks.
-     * @param {PreTrainedModel} [options.model] The model to use.
-     * @param {Processor} [options.processor] The processor to use.
+     * @param {ImagePipelineConstructorArgs} options An object used to instantiate the pipeline.
      */
     constructor(options) {
         super(options);
@@ -2077,11 +2154,7 @@ export class ZeroShotObjectDetectionPipeline extends Pipeline {
 
     /**
      * Create a new ZeroShotObjectDetectionPipeline.
-     * @param {Object} options An object containing the following properties:
-     * @param {string} [options.task] The task of the pipeline. Useful for specifying subtasks.
-     * @param {PreTrainedModel} [options.model] The model to use.
-     * @param {PreTrainedTokenizer} [options.tokenizer] The tokenizer to use.
-     * @param {Processor} [options.processor] The processor to use.
+     * @param {TextImagePipelineConstructorArgs} options An object used to instantiate the pipeline.
      */
     constructor(options) {
         super(options);
@@ -2163,11 +2236,7 @@ export class ZeroShotObjectDetectionPipeline extends Pipeline {
 export class DocumentQuestionAnsweringPipeline extends Pipeline {
     /**
      * Create a new DocumentQuestionAnsweringPipeline.
-     * @param {Object} options An object containing the following properties:
-     * @param {string} [options.task] The task of the pipeline. Useful for specifying subtasks.
-     * @param {PreTrainedModel} [options.model] The model to use.
-     * @param {PreTrainedTokenizer} [options.tokenizer] The tokenizer to use.
-     * @param {Processor} [options.processor] The processor to use.
+     * @param {TextImagePipelineConstructorArgs} options An object used to instantiate the pipeline.
      */
     constructor(options) {
         super(options);
@@ -2218,6 +2287,14 @@ export class DocumentQuestionAnsweringPipeline extends Pipeline {
     }
 }
 
+
+/**
+ * @typedef {Object} VocoderOptions
+ * @property {PreTrainedModel} [vocoder] The vocoder to use. If not provided, use the default HifiGan vocoder.
+ * 
+ * @typedef {TextAudioPipelineConstructorArgs & VocoderOptions} TextToAudioPipelineConstructorArgs
+ */
+
 /**
  * Text-to-audio generation pipeline using any `AutoModelForTextToWaveform` or `AutoModelForTextToSpectrogram`.
  * This pipeline generates an audio file from an input text and optional other conditional inputs.
@@ -2258,12 +2335,7 @@ export class TextToAudioPipeline extends Pipeline {
 
     /**
      * Create a new TextToAudioPipeline.
-     * @param {Object} options An object containing the following properties:
-     * @param {string} [options.task] The task of the pipeline. Useful for specifying subtasks.
-     * @param {PreTrainedModel} [options.model] The model to use.
-     * @param {PreTrainedTokenizer} [options.tokenizer] The tokenizer to use.
-     * @param {Processor} [options.processor] The processor to use.
-     * @param {PreTrainedModel} [options.vocoder] The vocoder to use.
+     * @param {TextToAudioPipelineConstructorArgs} options An object used to instantiate the pipeline.
      */
     constructor(options) {
         super(options);
@@ -2371,6 +2443,14 @@ export class TextToAudioPipeline extends Pipeline {
  */
 export class ImageToImagePipeline extends Pipeline {
     /**
+     * Create a new ImageToImagePipeline.
+     * @param {ImagePipelineConstructorArgs} options An object used to instantiate the pipeline.
+     */
+    constructor(options) {
+        super(options);
+    }
+
+    /**
      * Transform the image(s) passed as inputs.
      * @param {ImagePipelineInputs} images The images to transform.
      * @returns {Promise<any>} An image or a list of images containing result(s).
@@ -2415,6 +2495,14 @@ export class ImageToImagePipeline extends Pipeline {
  * ```
  */
 export class DepthEstimationPipeline extends Pipeline {
+    /**
+     * Create a new DepthEstimationPipeline.
+     * @param {ImagePipelineConstructorArgs} options An object used to instantiate the pipeline.
+     */
+    constructor(options) {
+        super(options);
+    }
+
     /**
      * Predicts the depth for the image(s) passed as inputs.
      * @param {ImagePipelineInputs} images The images to compute depth for.

--- a/src/pipelines.js
+++ b/src/pipelines.js
@@ -266,14 +266,22 @@ export class TokenClassificationPipeline extends Pipeline {
         }
 
         let tokenizer = this.tokenizer;
-        let [inputs, outputs] = await super._call(texts);
+
+        // Run tokenization
+        let model_inputs = this.tokenizer(texts, {
+            padding: true,
+            truncation: true,
+        });
+
+        // Run model
+        let outputs = await this.model(model_inputs)
 
         let logits = outputs.logits;
         let id2label = this.model.config.id2label;
 
         let toReturn = [];
         for (let i = 0; i < logits.dims[0]; ++i) {
-            let ids = inputs.input_ids[i];
+            let ids = model_inputs.input_ids[i];
             let batch = logits[i];
 
             // List of tokens that aren't ignored
@@ -358,7 +366,7 @@ export class QuestionAnsweringPipeline extends Pipeline {
         let inputs = this.tokenizer(question, {
             text_pair: context,
             padding: true,
-            truncation: true
+            truncation: true,
         });
 
         let output = await this.model(inputs);
@@ -438,19 +446,20 @@ export class FillMaskPipeline extends Pipeline {
         topk = 5
     } = {}) {
         // Run tokenization
-        let [inputs, outputs] = await super._call(texts);
+        let model_inputs = this.tokenizer(texts, {
+            padding: true,
+            truncation: true,
+        });
 
-        // Determine indices of mask tokens
-        // let mask_token_indices = inputs.input_ids.data.map(x => )
-
-        // let logits = reshape(outputs.logits.data, outputs.logits.dims);
+        // Run model
+        let outputs = await this.model(model_inputs)
 
         let tokenizer = this.tokenizer;
 
         let toReturn = [];
 
-        for (let i = 0; i < inputs.input_ids.dims[0]; ++i) {
-            let ids = inputs.input_ids[i];
+        for (let i = 0; i < model_inputs.input_ids.dims[0]; ++i) {
+            let ids = model_inputs.input_ids[i];
             let mask_token_index = ids.indexOf(this.tokenizer.mask_token_id)
 
             if (mask_token_index === -1) {
@@ -923,7 +932,15 @@ export class FeatureExtractionPipeline extends Pipeline {
         pooling = 'none',
         normalize = false,
     } = {}) {
-        let [inputs, outputs] = await super._call(texts);
+
+        // Run tokenization
+        let model_inputs = this.tokenizer(texts, {
+            padding: true,
+            truncation: true,
+        });
+
+        // Run model
+        let outputs = await this.model(model_inputs)
 
         // TODO: Provide warning to the user that they might be using model which was not exported
         // specifically for feature extraction
@@ -934,7 +951,7 @@ export class FeatureExtractionPipeline extends Pipeline {
         if (pooling === 'none') {
             // Skip pooling
         } else if (pooling === 'mean') {
-            result = mean_pooling(result, inputs.attention_mask);
+            result = mean_pooling(result, model_inputs.attention_mask);
         } else if (pooling === 'cls') {
             result = result.slice(null, 0);
         } else {
@@ -2008,7 +2025,7 @@ export class ZeroShotObjectDetectionPipeline extends Pipeline {
         // Run tokenization
         const text_inputs = this.tokenizer(candidate_labels, {
             padding: true,
-            truncation: true
+            truncation: true,
         });
 
         // Run processor
@@ -2090,7 +2107,7 @@ export class DocumentQuestionAnsweringPipeline extends Pipeline {
         const decoder_input_ids = this.tokenizer(task_prompt, {
             add_special_tokens: false,
             padding: true,
-            truncation: true
+            truncation: true,
         }).input_ids;
 
         // Run model
@@ -2194,7 +2211,7 @@ export class TextToAudioPipeline extends Pipeline {
         // Run tokenization
         const inputs = this.tokenizer(text_inputs, {
             padding: true,
-            truncation: true
+            truncation: true,
         });
 
         // Generate waveform
@@ -2236,7 +2253,7 @@ export class TextToAudioPipeline extends Pipeline {
         // Run tokenization
         const { input_ids } = this.tokenizer(text_inputs, {
             padding: true,
-            truncation: true
+            truncation: true,
         });
 
         // NOTE: At this point, we are guaranteed that `speaker_embeddings` is a `Tensor`

--- a/src/pipelines.js
+++ b/src/pipelines.js
@@ -130,7 +130,7 @@ export class Pipeline extends Callable {
  * @typedef {TextClassificationSingle[]} TextClassificationOutput
  * 
  * @callback TextClassificationPipelineCallback Classify the text(s) given as inputs.
- * @param {string|string[]} texts The input texts to be classified.
+ * @param {string|string[]} texts The input text(s) to be classified.
  * @param {Object} options An optional object containing the following properties:
  * @param {number} [options.topk=1] The number of top predictions to be returned.
  * @returns {Promise<TextClassificationOutput|TextClassificationOutput[]>} A promise that resolves to an array or object containing the predicted labels and scores.

--- a/src/pipelines.js
+++ b/src/pipelines.js
@@ -1606,9 +1606,7 @@ export class ImageClassificationPipeline extends Pipeline {
  * @property {string} label The label of the segment.
  * @property {number|null} score The score of the segment.
  * @property {RawImage} mask The mask of the segment.
- */
-
-/** 
+ * 
  * @callback ImageSegmentationPipelineCallback Segment the input images.
  * @param {ImagePipelineInputs} images The input images.
  * @param {Object} [options] The options to use for segmentation.
@@ -1620,9 +1618,6 @@ export class ImageClassificationPipeline extends Pipeline {
  * @param {Array} [options.target_sizes=null] List of target sizes for the input images. If not set, use the original image sizes.
  * @returns {Promise<ImageSegmentationPipelineOutput[]>} The annotated segments.
  */
-
-/** @type {new (_) => ImageSegmentationPipelineCallback} */
-const ImageSegmentationPipelineProxy = /** @type {any} */ (class extends Pipeline { });
 
 /**
  * Image segmentation pipeline using any `AutoModelForXXXSegmentation`.
@@ -1639,7 +1634,7 @@ const ImageSegmentationPipelineProxy = /** @type {any} */ (class extends Pipelin
  * // ]
  * ```
  */
-export class ImageSegmentationPipeline extends ImageSegmentationPipelineProxy {
+export class ImageSegmentationPipeline extends (/** @type {new (_) => ImageSegmentationPipelineCallback} */ (/** @type {any} */ (class extends Pipeline { }))) {
     /**
      * Create a new ImageSegmentationPipeline.
      * @param {Object} options An object containing the following properties:

--- a/src/utils/core.js
+++ b/src/utils/core.js
@@ -173,18 +173,3 @@ export function product(...a) {
 export function calculateReflectOffset(i, w) {
     return Math.abs((i + w) % (2 * w) - w);
 }
-
-/**
- * Helper function to convert list [xmin, xmax, ymin, ymax] into object { "xmin": xmin, ... }
- * @param {number[]} box The bounding box as a list.
- * @param {boolean} asInteger Whether to cast to integers.
- * @returns {Object} The bounding box as an object.
- */
-export function get_bounding_box(box, asInteger) {
-    if (asInteger) {
-        box = box.map(x => x | 0);
-    }
-    const [xmin, ymin, xmax, ymax] = box;
-
-    return { xmin, ymin, xmax, ymax };
-}

--- a/src/utils/core.js
+++ b/src/utils/core.js
@@ -76,17 +76,6 @@ export const Callable = /** @type {any} */ (class {
     }
 });
 
-
-/**
- * Check if a value is a string.
- * @param {*} text The value to check.
- * @returns {boolean} True if the value is a string, false otherwise.
- */
-export function isString(text) {
-    return typeof text === 'string' || text instanceof String
-}
-
-
 /**
  * Check if a value is a typed array.
  * @param {*} val The value to check.

--- a/src/utils/generation.js
+++ b/src/utils/generation.js
@@ -671,7 +671,7 @@ export const GenerationConfig = /** @type {any} */ (class {
 export class Sampler extends Callable {
     /**
      * Creates a new Sampler object with the specified generation config.
-     * @param {GenerationConfig} generation_config The generation config.
+     * @param {GenerationConfigType} generation_config The generation config.
      */
     constructor(generation_config) {
         super();
@@ -746,7 +746,7 @@ export class Sampler extends Callable {
 
     /**
      * Returns a Sampler object based on the specified options.
-     * @param {GenerationConfig} generation_config An object containing options for the sampler.
+     * @param {GenerationConfigType} generation_config An object containing options for the sampler.
      * @returns {Sampler} A Sampler object.
      */
     static getSampler(generation_config) {

--- a/src/utils/generation.js
+++ b/src/utils/generation.js
@@ -537,66 +537,72 @@ export class NoBadWordsLogitsProcessor extends LogitsProcessor {
 }
 
 /**
- * Class that holds a configuration for a generation task.
+ * @typedef {Object} GenerationConfigType The default configuration parameters.
+ * @property {number} [max_length=20] The maximum length the generated tokens can have. Corresponds to the length of the input prompt + `max_new_tokens`. Its effect is overridden by `max_new_tokens`, if also set.
+ * @property {number} [max_new_tokens=null] The maximum numbers of tokens to generate, ignoring the number of tokens in the prompt.
+ * @property {number} [min_length=0] The minimum length of the sequence to be generated. Corresponds to the length of the input prompt + `min_new_tokens`. Its effect is overridden by `min_new_tokens`, if also set.
+ * @property {number} [min_new_tokens=null] The minimum numbers of tokens to generate, ignoring the number of tokens in the prompt.
+ * @property {boolean|"never"} [early_stopping=false] Controls the stopping condition for beam-based methods, like beam-search. It accepts the following values:
+ * - `true`, where the generation stops as soon as there are `num_beams` complete candidates;
+ * - `false`, where an heuristic is applied and the generation stops when is it very unlikely to find better candidates;
+ * - `"never"`, where the beam search procedure only stops when there cannot be better candidates (canonical beam search algorithm).
+ * @property {number} [max_time=null] The maximum amount of time you allow the computation to run for in seconds. Generation will still finish the current pass after allocated time has been passed.
+ *
+ * @property {boolean} [do_sample=false] Whether or not to use sampling; use greedy decoding otherwise.
+ * @property {number} [num_beams=1] Number of beams for beam search. 1 means no beam search.
+ * @property {number} [num_beam_groups=1] Number of groups to divide `num_beams` into in order to ensure diversity among different groups of beams. See [this paper](https://arxiv.org/pdf/1610.02424.pdf) for more details.
+ * @property {number} [penalty_alpha=null] The values balance the model confidence and the degeneration penalty in contrastive search decoding.
+ * @property {boolean} [use_cache=true] Whether or not the model should use the past last key/values attentions (if applicable to the model) to speed up decoding.
+ *
+ * @property {number} [temperature=1.0] The value used to modulate the next token probabilities.
+ * @property {number} [top_k=50] The number of highest probability vocabulary tokens to keep for top-k-filtering.
+ * @property {number} [top_p=1.0] If set to float < 1, only the smallest set of most probable tokens with probabilities that add up to `top_p` or higher are kept for generation.
+ * @property {number} [typical_p=1.0] Local typicality measures how similar the conditional probability of predicting a target token next is to the expected conditional probability of predicting a random token next, given the partial text already generated. If set to float < 1, the smallest set of the most locally typical tokens with probabilities that add up to `typical_p` or higher are kept for generation. See [this paper](https://arxiv.org/pdf/2202.00666.pdf) for more details.
+ * @property {number} [epsilon_cutoff=0.0] If set to float strictly between 0 and 1, only tokens with a conditional probability greater than `epsilon_cutoff` will be sampled. In the paper, suggested values range from 3e-4 to 9e-4, depending on the size of the model. See [Truncation Sampling as Language Model Desmoothing](https://arxiv.org/abs/2210.15191) for more details.
+ * @property {number} [eta_cutoff=0.0] Eta sampling is a hybrid of locally typical sampling and epsilon sampling. If set to float strictly between 0 and 1, a token is only considered if it is greater than either `eta_cutoff` or `sqrt(eta_cutoff) * exp(-entropy(softmax(next_token_logits)))`. The latter term is intuitively the expected next token probability, scaled by `sqrt(eta_cutoff)`. In the paper, suggested values range from 3e-4 to 2e-3, depending on the size of the model. See [Truncation Sampling as Language Model Desmoothing](https://arxiv.org/abs/2210.15191) for more details.
+ * @property {number} [diversity_penalty=0.0] This value is subtracted from a beam's score if it generates a token same as any beam from other group at a particular time. Note that `diversity_penalty` is only effective if `group beam search` is enabled.
+ * @property {number} [repetition_penalty=1.0] The parameter for repetition penalty. 1.0 means no penalty. See [this paper](https://arxiv.org/pdf/1909.05858.pdf) for more details.
+ * @property {number} [encoder_repetition_penalty=1.0] The paramater for encoder_repetition_penalty. An exponential penalty on sequences that are not in the original input. 1.0 means no penalty.
+ * @property {number} [length_penalty=1.0] Exponential penalty to the length that is used with beam-based generation. It is applied as an exponent to the sequence length, which in turn is used to divide the score of the sequence. Since the score is the log likelihood of the sequence (i.e. negative), `length_penalty` > 0.0 promotes longer sequences, while `length_penalty` < 0.0 encourages shorter sequences.
+ * @property {number} [no_repeat_ngram_size=0] If set to int > 0, all ngrams of that size can only occur once.
+ * @property {number[][]} [bad_words_ids=null] List of token ids that are not allowed to be generated. In order to get the token ids of the words that should not appear in the generated text, use `(await tokenizer(bad_words, {add_prefix_space: true, add_special_tokens: false})).input_ids`.
+ * @property {number[][]|number[][][]} [force_words_ids=null] List of token ids that must be generated. If given a `number[][]`, this is treated as a simple list of words that must be included, the opposite to `bad_words_ids`. If given `number[][][]`, this triggers a [disjunctive constraint](https://github.com/huggingface/transformers/issues/14081), where one can allow different forms of each word.
+ * @property {boolean} [renormalize_logits=false] Whether to renormalize the logits after applying all the logits processors or warpers (including the custom ones). It's highly recommended to set this flag to `true` as the search algorithms suppose the score logits are normalized but some logit processors or warpers break the normalization.
+ * @property {Object[]} [constraints=null] Custom constraints that can be added to the generation to ensure that the output will contain the use of certain tokens as defined by `Constraint` objects, in the most sensible way possible.
+ * 
+ * @property {number} [forced_bos_token_id=null] The id of the token to force as the first generated token after the `decoder_start_token_id`. Useful for multilingual models like mBART where the first generated token needs to be the target language token.
+ * @property {number|number[]} [forced_eos_token_id=null] The id of the token to force as the last generated token when `max_length` is reached. Optionally, use a list to set multiple *end-of-sequence* tokens.
+ * @property {boolean} [remove_invalid_values=false] Whether to remove possible *nan* and *inf* outputs of the model to prevent the generation method to crash. Note that using `remove_invalid_values` can slow down generation.
+ * @property {number[]} [exponential_decay_length_penalty=null] This Tuple adds an exponentially increasing length penalty, after a certain amount of tokens have been generated. The tuple shall consist of: `(start_index, decay_factor)` where `start_index` indicates where penalty starts and `decay_factor` represents the factor of exponential decay.
+ * @property {number[]} [suppress_tokens=null] A list of tokens that will be suppressed at generation. The `SupressTokens` logit processor will set their log probs to `-inf` so that they are not sampled.
+ * @property {number[]} [begin_suppress_tokens=null] A list of tokens that will be suppressed at the beginning of the generation. The `SupressBeginTokens` logit processor will set their log probs to `-inf` so that they are not sampled.
+ * @property {number[][]} [forced_decoder_ids=null] A list of pairs of integers which indicates a mapping from generation indices to token indices that will be forced before sampling. For example, `[[1, 123]]` means the second generated token will always be a token of index 123.
+ * 
+ * @property {number} [num_return_sequences=1] The number of independently computed returned sequences for each element in the batch.
+ * @property {boolean} [output_attentions=false] Whether or not to return the attentions tensors of all attention layers. See `attentions` under returned tensors for more details.
+ * @property {boolean} [output_hidden_states=false] Whether or not to return the hidden states of all layers. See `hidden_states` under returned tensors for more details.
+ * @property {boolean} [output_scores=false] Whether or not to return the prediction scores. See `scores` under returned tensors for more details.
+ * @property {boolean} [return_dict_in_generate=false] Whether or not to return a `ModelOutput` instead of a plain tuple.
+ * 
+ * @property {number} [pad_token_id=null] The id of the *padding* token.
+ * @property {number} [bos_token_id=null] The id of the *beginning-of-sequence* token.
+ * @property {number|number[]} [eos_token_id=null] The id of the *end-of-sequence* token. Optionally, use a list to set multiple *end-of-sequence* tokens.
+ * 
+ * @property {number} [encoder_no_repeat_ngram_size=0] If set to int > 0, all ngrams of that size that occur in the `encoder_input_ids` cannot occur in the `decoder_input_ids`.
+ * @property {number} [decoder_start_token_id=null] If an encoder-decoder model starts decoding with a different token than *bos*, the id of that token.
+ * 
+ * @property {Object} [generation_kwargs={}] Additional generation kwargs will be forwarded to the `generate` function of the model. Kwargs that are not present in `generate`'s signature will be used in the model forward pass.
  */
-export class GenerationConfig {
+
+/**
+ * Class that holds a configuration for a generation task.
+ * @type {new (kwargs?: GenerationConfigType) => GenerationConfigType}
+ */
+export const GenerationConfig = /** @type {any} */ (class {
+
     /**
-     * Create a GenerationConfig object
-     * @param {Object} [kwargs={}] The configuration parameters. If not set, the default values are used.
-     * @param {number} [kwargs.max_length=20] The maximum length the generated tokens can have. Corresponds to the length of the input prompt + `max_new_tokens`. Its effect is overridden by `max_new_tokens`, if also set.
-     * @param {number} [kwargs.max_new_tokens=null] The maximum numbers of tokens to generate, ignoring the number of tokens in the prompt.
-     * @param {number} [kwargs.min_length=0] The minimum length of the sequence to be generated. Corresponds to the length of the input prompt + `min_new_tokens`. Its effect is overridden by `min_new_tokens`, if also set.
-     * @param {number} [kwargs.min_new_tokens=null] The minimum numbers of tokens to generate, ignoring the number of tokens in the prompt.
-     * @param {boolean|"never"} [kwargs.early_stopping=false] Controls the stopping condition for beam-based methods, like beam-search. It accepts the following values:
-     * - `true`, where the generation stops as soon as there are `num_beams` complete candidates;
-     * - `false`, where an heuristic is applied and the generation stops when is it very unlikely to find better candidates;
-     * - `"never"`, where the beam search procedure only stops when there cannot be better candidates (canonical beam search algorithm).
-     * @param {number} [kwargs.max_time=null] The maximum amount of time you allow the computation to run for in seconds. Generation will still finish the current pass after allocated time has been passed.
-     *
-     * @param {boolean} [kwargs.do_sample=false] Whether or not to use sampling; use greedy decoding otherwise.
-     * @param {number} [kwargs.num_beams=1] Number of beams for beam search. 1 means no beam search.
-     * @param {number} [kwargs.num_beam_groups=1] Number of groups to divide `num_beams` into in order to ensure diversity among different groups of beams. See [this paper](https://arxiv.org/pdf/1610.02424.pdf) for more details.
-     * @param {number} [kwargs.penalty_alpha=null] The values balance the model confidence and the degeneration penalty in contrastive search decoding.
-     * @param {boolean} [kwargs.use_cache=true] Whether or not the model should use the past last key/values attentions (if applicable to the model) to speed up decoding.
-     *
-     * @param {number} [kwargs.temperature=1.0] The value used to modulate the next token probabilities.
-     * @param {number} [kwargs.top_k=50] The number of highest probability vocabulary tokens to keep for top-k-filtering.
-     * @param {number} [kwargs.top_p=1.0] If set to float < 1, only the smallest set of most probable tokens with probabilities that add up to `top_p` or higher are kept for generation.
-     * @param {number} [kwargs.typical_p=1.0] Local typicality measures how similar the conditional probability of predicting a target token next is to the expected conditional probability of predicting a random token next, given the partial text already generated. If set to float < 1, the smallest set of the most locally typical tokens with probabilities that add up to `typical_p` or higher are kept for generation. See [this paper](https://arxiv.org/pdf/2202.00666.pdf) for more details.
-     * @param {number} [kwargs.epsilon_cutoff=0.0] If set to float strictly between 0 and 1, only tokens with a conditional probability greater than `epsilon_cutoff` will be sampled. In the paper, suggested values range from 3e-4 to 9e-4, depending on the size of the model. See [Truncation Sampling as Language Model Desmoothing](https://arxiv.org/abs/2210.15191) for more details.
-     * @param {number} [kwargs.eta_cutoff=0.0] Eta sampling is a hybrid of locally typical sampling and epsilon sampling. If set to float strictly between 0 and 1, a token is only considered if it is greater than either `eta_cutoff` or `sqrt(eta_cutoff) * exp(-entropy(softmax(next_token_logits)))`. The latter term is intuitively the expected next token probability, scaled by `sqrt(eta_cutoff)`. In the paper, suggested values range from 3e-4 to 2e-3, depending on the size of the model. See [Truncation Sampling as Language Model Desmoothing](https://arxiv.org/abs/2210.15191) for more details.
-     * @param {number} [kwargs.diversity_penalty=0.0] This value is subtracted from a beam's score if it generates a token same as any beam from other group at a particular time. Note that `diversity_penalty` is only effective if `group beam search` is enabled.
-     * @param {number} [kwargs.repetition_penalty=1.0] The parameter for repetition penalty. 1.0 means no penalty. See [this paper](https://arxiv.org/pdf/1909.05858.pdf) for more details.
-     * @param {number} [kwargs.encoder_repetition_penalty=1.0] The paramater for encoder_repetition_penalty. An exponential penalty on sequences that are not in the original input. 1.0 means no penalty.
-     * @param {number} [kwargs.length_penalty=1.0] Exponential penalty to the length that is used with beam-based generation. It is applied as an exponent to the sequence length, which in turn is used to divide the score of the sequence. Since the score is the log likelihood of the sequence (i.e. negative), `length_penalty` > 0.0 promotes longer sequences, while `length_penalty` < 0.0 encourages shorter sequences.
-     * @param {number} [kwargs.no_repeat_ngram_size=0] If set to int > 0, all ngrams of that size can only occur once.
-     * @param {number[][]} [kwargs.bad_words_ids=null] List of token ids that are not allowed to be generated. In order to get the token ids of the words that should not appear in the generated text, use `(await tokenizer(bad_words, {add_prefix_space: true, add_special_tokens: false})).input_ids`.
-     * @param {number[][]|number[][][]} [kwargs.force_words_ids=null] List of token ids that must be generated. If given a `number[][]`, this is treated as a simple list of words that must be included, the opposite to `bad_words_ids`. If given `number[][][]`, this triggers a [disjunctive constraint](https://github.com/huggingface/transformers/issues/14081), where one can allow different forms of each word.
-     * @param {boolean} [kwargs.renormalize_logits=false] Whether to renormalize the logits after applying all the logits processors or warpers (including the custom ones). It's highly recommended to set this flag to `true` as the search algorithms suppose the score logits are normalized but some logit processors or warpers break the normalization.
-     * @param {Object[]} [kwargs.constraints=null] Custom constraints that can be added to the generation to ensure that the output will contain the use of certain tokens as defined by `Constraint` objects, in the most sensible way possible.
-     * 
-     * @param {number} [kwargs.forced_bos_token_id=null] The id of the token to force as the first generated token after the `decoder_start_token_id`. Useful for multilingual models like mBART where the first generated token needs to be the target language token.
-     * @param {number|number[]} [kwargs.forced_eos_token_id=null] The id of the token to force as the last generated token when `max_length` is reached. Optionally, use a list to set multiple *end-of-sequence* tokens.
-     * @param {boolean} [kwargs.remove_invalid_values=false] Whether to remove possible *nan* and *inf* outputs of the model to prevent the generation method to crash. Note that using `remove_invalid_values` can slow down generation.
-     * @param {number[]} [kwargs.exponential_decay_length_penalty=null] This Tuple adds an exponentially increasing length penalty, after a certain amount of tokens have been generated. The tuple shall consist of: `(start_index, decay_factor)` where `start_index` indicates where penalty starts and `decay_factor` represents the factor of exponential decay.
-     * @param {number[]} [kwargs.suppress_tokens=null] A list of tokens that will be suppressed at generation. The `SupressTokens` logit processor will set their log probs to `-inf` so that they are not sampled.
-     * @param {number[]} [kwargs.begin_suppress_tokens=null] A list of tokens that will be suppressed at the beginning of the generation. The `SupressBeginTokens` logit processor will set their log probs to `-inf` so that they are not sampled.
-     * @param {number[][]} [kwargs.forced_decoder_ids=null] A list of pairs of integers which indicates a mapping from generation indices to token indices that will be forced before sampling. For example, `[[1, 123]]` means the second generated token will always be a token of index 123.
-     * 
-     * @param {number} [kwargs.num_return_sequences=1] The number of independently computed returned sequences for each element in the batch.
-     * @param {boolean} [kwargs.output_attentions=false] Whether or not to return the attentions tensors of all attention layers. See `attentions` under returned tensors for more details.
-     * @param {boolean} [kwargs.output_hidden_states=false] Whether or not to return the hidden states of all layers. See `hidden_states` under returned tensors for more details.
-     * @param {boolean} [kwargs.output_scores=false] Whether or not to return the prediction scores. See `scores` under returned tensors for more details.
-     * @param {boolean} [kwargs.return_dict_in_generate=false] Whether or not to return a `ModelOutput` instead of a plain tuple.
-     * 
-     * @param {number} [kwargs.pad_token_id=null] The id of the *padding* token.
-     * @param {number} [kwargs.bos_token_id=null] The id of the *beginning-of-sequence* token.
-     * @param {number|number[]} [kwargs.eos_token_id=null] The id of the *end-of-sequence* token. Optionally, use a list to set multiple *end-of-sequence* tokens.
-     * 
-     * @param {number} [kwargs.encoder_no_repeat_ngram_size=0] If set to int > 0, all ngrams of that size that occur in the `encoder_input_ids` cannot occur in the `decoder_input_ids`.
-     * @param {number} [kwargs.decoder_start_token_id=null] If an encoder-decoder model starts decoding with a different token than *bos*, the id of that token.
-     * 
-     * @param {Object} [kwargs.generation_kwargs={}] Additional generation kwargs will be forwarded to the `generate` function of the model. Kwargs that are not present in `generate`'s signature will be used in the model forward pass.
+     * Create a new GenerationConfig object.
+     * @param {GenerationConfigType} kwargs 
      */
     constructor(kwargs = {}) {
         // Parameters that control the length of the output
@@ -657,8 +663,7 @@ export class GenerationConfig {
         // Wild card
         this.generation_kwargs = kwargs.generation_kwargs ?? {};
     }
-}
-
+});
 
 /**
  * Sampler is a base class for all sampling methods used for text generation.

--- a/src/utils/image.js
+++ b/src/utils/image.js
@@ -8,7 +8,6 @@
  * @module utils/image
  */
 
-import { isString } from './core.js';
 import { getFile } from './hub.js';
 import { env } from '../env.js';
 
@@ -114,7 +113,7 @@ export class RawImage {
     static async read(input) {
         if (input instanceof RawImage) {
             return input;
-        } else if (isString(input) || input instanceof URL) {
+        } else if (typeof input === 'string' || input instanceof URL) {
             return await this.fromURL(input);
         } else {
             throw new Error(`Unsupported input type: ${typeof input}`);

--- a/src/utils/maths.js
+++ b/src/utils/maths.js
@@ -181,8 +181,8 @@ export function dot(arr1, arr2) {
 /**
  * Get the top k items from an iterable, sorted by descending order
  * @param {any[]|TypedArray} items The items to be sorted
- * @param {number} [top_k=0] The number of top items to return (default: 0 = return all)
- * @returns {Array} The top k items, sorted by descending order
+ * @param {number|null} [top_k=0] The number of top items to return (default: 0 = return all)
+ * @returns {[number, any][]} The top k items, sorted by descending order
  */
 export function getTopItems(items, top_k = 0) {
     // if top == 0, return all
@@ -191,7 +191,7 @@ export function getTopItems(items, top_k = 0) {
         .map((x, i) => [i, x])            // Get indices ([index, score])
         .sort((a, b) => b[1] - a[1])      // Sort by log probabilities
 
-    if (top_k > 0) {
+    if (top_k !== null && top_k > 0) {
         items = items.slice(0, top_k);    // Get top k items
     }
 


### PR DESCRIPTION
A first attempt at improving the types inferred when creating a new pipeline.

![image](https://github.com/xenova/transformers.js/assets/26504141/a2fb9ada-ad86-41d4-81aa-bcea9997b36b)


Still to do: return actual call parameters instead of `(...args: any[]) => any`.

Closes #484. 

