### PR TITLE
Add `phi-1_5` model

### DIFF
--- a/scripts/convert.py
+++ b/scripts/convert.py
@@ -75,6 +75,10 @@ MODEL_SPECIFIC_QUANTIZE_PARAMS = {
         'per_channel': False,
         'reduce_range': False,
     },
+    'phi': {
+        'per_channel': False,
+        'reduce_range': False,
+    },
 
     # Encoder-decoder models
     'whisper': {

--- a/scripts/supported_models.py
+++ b/scripts/supported_models.py
@@ -714,6 +714,7 @@ SUPPORTED_MODELS = {
         # Text generation
         'text-generation': [
             'hf-internal-testing/tiny-random-PhiForCausalLM',
+            'susnato/phi-1_5_dev',
         ],
     },
     'roberta': {


### PR DESCRIPTION
closes #492. Converted model: [Xenova/phi-1_5_dev](https://huggingface.co/Xenova/phi-1_5_dev) (from [susnato/phi-1_5_dev](https://huggingface.co/susnato/phi-1_5_dev), which is the transformers-compatible version of [microsoft/phi-1_5](https://huggingface.co/microsoft/phi-1_5))


**Example:** Text generation (code completion) with `Xenova/phi-1_5_dev`.

```js
import { pipeline } from '@xenova/transformers';

// Create a text-generation pipeline
const generator = await pipeline('text-generation', 'Xenova/phi-1_5_dev');

// Construct prompt
const prompt = `\`\`\`py
import math
def print_prime(n):
    """
    Print all primes between 1 and n
    """`;

// Generate text
const result = await generator(prompt, {
  max_new_tokens: 100,
});
console.log(result[0].generated_text);
```

Results in:
```py
import math
def print_prime(n):
    """
    Print all primes between 1 and n
    """
    primes = []
    for num in range(2, n+1):
        is_prime = True
        for i in range(2, int(math.sqrt(num))+1):
            if num % i == 0:
                is_prime = False
                break
        if is_prime:
            primes.append(num)
    print(primes)

print_prime(20)
```

Running the code produces the correct result:
```
[2, 3, 5, 7, 11, 13, 17, 19]
```
