### PR TITLE
Encode revision in remote URL

### DIFF
--- a/src/utils/hub.js
+++ b/src/utils/hub.js
@@ -398,7 +398,7 @@ export async function getModelFile(path_or_repo_id, filename, fatal = true, opti
         env.remoteHost,
         env.remotePathTemplate
             .replaceAll('{model}', path_or_repo_id)
-            .replaceAll('{revision}', revision),
+            .replaceAll('{revision}', encodeURIComponent(revision)),
         filename
     );
 


### PR DESCRIPTION
Required to support accessing PRs on the HF Hub. e.g., 


```js
const pipe = await pipeline('task', 'model', {
   revision: 'refs/pr/1', // Access files from PR
});
```