### PR TITLE
Prevent electron use node backend

### DIFF
--- a/src/backends/onnx.js
+++ b/src/backends/onnx.js
@@ -29,7 +29,7 @@ export const executionProviders = [
     'wasm'
 ];
 
-if (typeof process !== 'undefined' && process?.release?.name === 'node') {
+if (typeof process !== 'undefined' && process?.release?.name === 'node' && process?.type !== 'renderer') {
     // Running in a node-like environment.
     ONNX = ONNX_NODE.default ?? ONNX_NODE;
 


### PR DESCRIPTION
As title.

Prevent using the node backend when Electron disabled isolation.