### PR TITLE
Add support for exporting custom models

### DIFF
--- a/scripts/convert.py
+++ b/scripts/convert.py
@@ -296,8 +296,12 @@ def main():
     # Create output folder
     os.makedirs(output_model_folder, exist_ok=True)
 
+    from_pretrained_kwargs = dict(
+        trust_remote_code=conv_args.trust_remote_code,
+    )
+
     # Saving the model config
-    config = AutoConfig.from_pretrained(model_id, trust_remote_code=conv_args.trust_remote_code)
+    config = AutoConfig.from_pretrained(model_id, **from_pretrained_kwargs)
 
     custom_kwargs={}
     if conv_args.custom_onnx_configs is not None:
@@ -315,7 +319,7 @@ def main():
     tokenizer = None
     try:
         # Load tokenizer
-        tokenizer = AutoTokenizer.from_pretrained(tokenizer_id)
+        tokenizer = AutoTokenizer.from_pretrained(tokenizer_id, **from_pretrained_kwargs)
 
         # To avoid inserting all chat templates into tokenizers.js, we save the chat template
         # to the tokenizer_config.json file, and load it when the tokenizer is loaded.
@@ -417,8 +421,8 @@ def main():
             from .extra.clip import CLIPTextModelWithProjectionOnnxConfig, CLIPVisionModelWithProjectionOnnxConfig
             from transformers.models.clip import CLIPTextModelWithProjection, CLIPVisionModelWithProjection
 
-            text_model = CLIPTextModelWithProjection.from_pretrained(model_id)
-            vision_model = CLIPVisionModelWithProjection.from_pretrained(model_id)
+            text_model = CLIPTextModelWithProjection.from_pretrained(model_id, **from_pretrained_kwargs)
+            vision_model = CLIPVisionModelWithProjection.from_pretrained(model_id, **from_pretrained_kwargs)
 
             export_models(
                 models_and_onnx_configs={
@@ -433,8 +437,8 @@ def main():
             from .extra.siglip import SiglipTextModelOnnxConfig, SiglipVisionModelOnnxConfig
             from transformers.models.siglip import SiglipTextModel, SiglipVisionModel
 
-            text_model = SiglipTextModel.from_pretrained(model_id)
-            vision_model = SiglipVisionModel.from_pretrained(model_id)
+            text_model = SiglipTextModel.from_pretrained(model_id, **from_pretrained_kwargs)
+            vision_model = SiglipVisionModel.from_pretrained(model_id, **from_pretrained_kwargs)
 
             export_models(
                 models_and_onnx_configs={
@@ -450,8 +454,8 @@ def main():
         #     from .extra.clap import ClapTextModelWithProjectionOnnxConfig, ClapAudioModelWithProjectionOnnxConfig
         #     from transformers.models.clap import ClapTextModelWithProjection, ClapAudioModelWithProjection
 
-        #     text_model = ClapTextModelWithProjection.from_pretrained(model_id)
-        #     audio_model = ClapAudioModelWithProjection.from_pretrained(model_id)
+        #     text_model = ClapTextModelWithProjection.from_pretrained(model_id, **from_pretrained_kwargs)
+        #     audio_model = ClapAudioModelWithProjection.from_pretrained(model_id, **from_pretrained_kwargs)
 
         #     export_models(
         #         models_and_onnx_configs={
@@ -496,7 +500,7 @@ def main():
         from transformers import GenerationConfig
         from .extra.whisper import get_alignment_heads
 
-        generation_config = GenerationConfig.from_pretrained(model_id)
+        generation_config = GenerationConfig.from_pretrained(model_id, **from_pretrained_kwargs)
         generation_config.alignment_heads = get_alignment_heads(config)
         generation_config.save_pretrained(output_model_folder)
 

--- a/scripts/convert.py
+++ b/scripts/convert.py
@@ -301,10 +301,13 @@ def main():
 
     custom_kwargs={}
     if conv_args.custom_onnx_configs is not None:
+        if conv_args.task == 'auto':
+            raise Exception('`--task` must be set when exporting with `--custom_onnx_configs`')
         custom_onnx_configs = json.loads(conv_args.custom_onnx_configs)
 
         for key in custom_onnx_configs:
-            mapping = TasksManager._SUPPORTED_MODEL_TYPE[custom_onnx_configs[key]]['onnx'][conv_args.task]
+            onnx_configs = TasksManager._SUPPORTED_MODEL_TYPE[custom_onnx_configs[key]]['onnx']
+            mapping = onnx_configs[conv_args.task]
             custom_onnx_configs[key] = mapping.func(config, **mapping.keywords)
 
         custom_kwargs['custom_onnx_configs'] = custom_onnx_configs

--- a/src/models.js
+++ b/src/models.js
@@ -1472,6 +1472,12 @@ export class BertForQuestionAnswering extends BertPreTrainedModel {
 //////////////////////////////////////////////////
 
 //////////////////////////////////////////////////
+// NomicBert models
+export class NomicBertPreTrainedModel extends PreTrainedModel { }
+export class NomicBertModel extends NomicBertPreTrainedModel { }
+//////////////////////////////////////////////////
+
+//////////////////////////////////////////////////
 // RoFormer models
 export class RoFormerPreTrainedModel extends PreTrainedModel { }
 
@@ -5177,6 +5183,7 @@ export class PretrainedMixin {
 
 const MODEL_MAPPING_NAMES_ENCODER_ONLY = new Map([
     ['bert', ['BertModel', BertModel]],
+    ['nomic_bert', ['NomicBertModel', NomicBertModel]],
     ['roformer', ['RoFormerModel', RoFormerModel]],
     ['electra', ['ElectraModel', ElectraModel]],
     ['esm', ['EsmModel', EsmModel]],


### PR DESCRIPTION

Needed for https://huggingface.co/nomic-ai/nomic-embed-text-v1

Example:
```
$ python -m scripts.convert --model_id nomic-ai/nomic-embed-text-v1 --opset 12 --custom_onnx_configs '{"model":"bert"}' --trust_remote_code --task feature-extraction
Framework not specified. Using pt to export to ONNX.
<All keys matched successfully>
Using framework PyTorch: 2.1.2+cu121
Overriding 1 configuration item(s)
        - use_cache -> False
/home/codespace/.cache/huggingface/modules/transformers_modules/nomic-ai/nomic-embed-text-v1/98b6aaaf6dc0f3d1fd63f6cb72593fc3b9a8ac9e/modeling_hf_nomic_bert.py:631: TracerWarning: Converting a tensor to a Python boolean might cause the trace to be incorrect. We can't record the data flow of Python values, so this value will be treated as a constant in the future. This means that the trace might not generalize to other inputs!
  if seqlen > self._seq_len_cached:
/home/codespace/.cache/huggingface/modules/transformers_modules/nomic-ai/nomic-embed-text-v1/98b6aaaf6dc0f3d1fd63f6cb72593fc3b9a8ac9e/modeling_hf_nomic_bert.py:584: TracerWarning: Converting a tensor to a Python boolean might cause the trace to be incorrect. We can't record the data flow of Python values, so this value will be treated as a constant in the future. This means that the trace might not generalize to other inputs!
  seqlen > self._seq_len_cached
/home/codespace/.cache/huggingface/modules/transformers_modules/nomic-ai/nomic-embed-text-v1/98b6aaaf6dc0f3d1fd63f6cb72593fc3b9a8ac9e/modeling_hf_nomic_bert.py:514: TracerWarning: Converting a tensor to a Python boolean might cause the trace to be incorrect. We can't record the data flow of Python values, so this value will be treated as a constant in the future. This means that the trace might not generalize to other inputs!
  assert ro_dim <= x.shape[-1]
Post-processing the exported models...
Deduplicating shared (tied) weights...
Validating ONNX model models/nomic-ai/nomic-embed-text-v1/model.onnx...
        -[✓] ONNX model output names match reference model (last_hidden_state)
        - Validating ONNX Model output "last_hidden_state":
                -[✓] (2, 16, 768) matches (2, 16, 768)
                -[✓] all values close (atol: 0.0001)
The ONNX export succeeded and the exported model was saved at: models/nomic-ai/nomic-embed-text-v1
```
