### PR TITLE
[custom model] Add support for MODNet

### DIFF
--- a/src/processors.js
+++ b/src/processors.js
@@ -188,6 +188,20 @@ function constraint_to_multiple_of(val, multiple, minVal = 0, maxVal = null) {
 }
 
 /**
+ * Rounds the height and width down to the closest multiple of size_divisibility
+ * @param {[number, number]} size The size of the image
+ * @param {number} divisor The divisor to use.
+ * @returns {[number, number]} The rounded size.
+ */
+function enforce_size_divisibility([width, height], divisor) {
+    return [
+        Math.floor(width / divisor) * divisor,
+        Math.floor(height / divisor) * divisor
+    ];
+}
+
+
+/**
  * Base class for feature extractors.
  *
  * @extends Callable
@@ -229,7 +243,7 @@ export class ImageFeatureExtractor extends FeatureExtractor {
      * @param {boolean} config.do_normalize Whether to normalize the image pixel values.
      * @param {boolean} config.do_resize Whether to resize the image.
      * @param {number} config.resample What method to use for resampling.
-     * @param {number} config.size The size to resize the image to.
+     * @param {number|Object} config.size The size to resize the image to.
      */
     constructor(config) {
         super(config);
@@ -481,9 +495,12 @@ export class ImageFeatureExtractor extends FeatureExtractor {
                 : Math.min(longest_edge / newWidth, longest_edge / newHeight);
 
             // To avoid certain floating point precision issues, we round to 2 decimal places
-            const finalWidth = Math.floor(Number((newWidth * longResizeFactor).toFixed(2)));
-            const finalHeight = Math.floor(Number((newHeight * longResizeFactor).toFixed(2)));
+            let finalWidth = Math.floor(Number((newWidth * longResizeFactor).toFixed(2)));
+            let finalHeight = Math.floor(Number((newHeight * longResizeFactor).toFixed(2)));
 
+            if (this.size_divisibility !== undefined) {
+                [finalWidth, finalHeight] = enforce_size_divisibility([finalWidth, finalHeight], this.size_divisibility)
+            }
             return [finalWidth, finalHeight];
 
         } else if (size !== undefined && size.width !== undefined && size.height !== undefined) {
@@ -515,10 +532,7 @@ export class ImageFeatureExtractor extends FeatureExtractor {
             return [newWidth, newHeight];
 
         } else if (this.size_divisibility !== undefined) {
-            // Rounds the height and width down to the closest multiple of size_divisibility
-            const newWidth = Math.floor(srcWidth / this.size_divisibility) * this.size_divisibility;
-            const newHeight = Math.floor(srcHeight / this.size_divisibility) * this.size_divisibility;
-            return [newWidth, newHeight];
+            return enforce_size_divisibility([srcWidth, srcHeight], this.size_divisibility);
         } else {
             throw new Error(`Could not resize image due to unsupported \`this.size\` option in config: ${JSON.stringify(size)}`);
         }
@@ -2094,6 +2108,7 @@ export class OwlViTProcessor extends Processor { }
  */
 export class AutoProcessor {
     static FEATURE_EXTRACTOR_CLASS_MAPPING = {
+        ImageFeatureExtractor,
         WhisperFeatureExtractor,
         ViTFeatureExtractor,
         MobileViTFeatureExtractor,


### PR DESCRIPTION
This PR is a step towards supporting custom models (even those not supported by [transformers](https://github.com/huggingface/transformers)).

In this case, the main additional requirement is to support `size_divisbility` after resizing. Future PRs will add:
- A way to remove the `unsupported` warning.
- A way to set what type of model it is (encoder-only, encoder-decoder, decoder-only, etc).

## Usage:
```js
import { AutoProcessor, RawImage, AutoModel } from '@xenova/transformers';

// Load model and processor
const model = await AutoModel.from_pretrained('Xenova/modnet-onnx', { quantized: false });
const processor = await AutoProcessor.from_pretrained('Xenova/modnet-onnx');

// Load image from URL
const url = 'https://images.pexels.com/photos/5965592/pexels-photo-5965592.jpeg?auto=compress&cs=tinysrgb&w=1024';
const image = await RawImage.fromURL(url);

// Process image
const { pixel_values: input } = await processor(image);

// Predict alpha matte
const { output } = await model({input});

// Save output image
const outputImage = await RawImage.fromTensor(output[0].mul(255).to('uint8')).resize(image.width, image.height);
outputImage.save('output.png');
```

| Input image | Visualized mask |
|--------|--------|
| ![image](https://github.com/xenova/transformers.js/assets/26504141/9fe8d352-3eea-42f1-88ef-dea34043d4b9) | ![image](https://github.com/xenova/transformers.js/assets/26504141/950afe1c-2538-4b7d-bd78-d6b48b248096) | 



For more information, see the original [repo](https://github.com/ZHKKKe/MODNet) and example [colab](https://colab.research.google.com/drive/1P3cWtg8fnmu9karZHYDAtmm1vj1rgA-f?usp=sharing).