### PR TITLE
variable `ONNX` undefined in tensor.js fix

### DIFF
--- a/BuildDocumentation
+++ b/BuildDocumentation
@@ -1,0 +1,10 @@
+Requirements
+  Node version >= 18
+
+Commands:
+  Clone this repository
+  npm install -> this will install all the dependancies for this library
+  npx webpack --config webpack.config.js -> this command will use webpack configuration and compile the branch
+
+Output:
+  transformer.js -> loacated in dist/

--- a/src/backends/onnx.js
+++ b/src/backends/onnx.js
@@ -25,7 +25,7 @@ import * as ONNX_NODE from 'onnxruntime-node';
 import * as ONNX_WEB from 'onnxruntime-web';
 
 /** @type {import('onnxruntime-web')|import('onnxruntime-node')} The ONNX runtime module. */
-let ONNX;
+export let ONNX;
 
 const WEBGPU_AVAILABLE = typeof navigator !== 'undefined' && 'gpu' in navigator;
 const USE_ONNXRUNTIME_NODE = typeof process !== 'undefined' && process?.release?.name === 'node'

--- a/src/utils/tensor.js
+++ b/src/utils/tensor.js
@@ -7,6 +7,8 @@
  * @module utils/tensor
  */
 
+import { ONNX } from '../backends/onnx.js';
+
 import {
     interpolate_data,
     transpose_data


### PR DESCRIPTION
After compiling branch `v3` as webpack module 

```
Uncaught ReferenceError: ONNX is not defined
    at tensor.js:37:1
    at transformers.js:24:34
```
Got this exception due to variable `ONNX` variable is not exported in `onnx.js` file as well as it is not imported in `tensor.js` file.

this PR addresses this issue and this changeset will resolve this runtime error