### PR TITLE
Add basic 2D `layer_norm` operator

### DIFF
--- a/tests/tensor.test.js
+++ b/tests/tensor.test.js
@@ -1,7 +1,7 @@
 
 import { Tensor } from '../src/transformers.js';
 import { compare } from './test_utils.js';
-import { cat, mean, stack } from '../src/utils/tensor.js';
+import { cat, mean, stack, layer_norm } from '../src/utils/tensor.js';
 
 describe('Tensor operations', () => {
 
@@ -103,7 +103,6 @@ describe('Tensor operations', () => {
         });
     });
 
-
     describe('mean', () => {
         it('should calculate mean', async () => {
             const t1 = new Tensor('float32', [1, 2, 3, 4, 5, 6], [2, 3, 1]);
@@ -127,5 +126,19 @@ describe('Tensor operations', () => {
             compare(avg2, target2, 1e-3);
 
         })
+    });
+
+    describe('layer_norm', () => {
+        it('should calculate layer norm', async () => {
+            const t1 = new Tensor('float32', [1, 2, 3, 4, 5, 6], [2, 3]);
+
+            const target = new Tensor('float32', [
+                -1.2247356176376343, 0.0, 1.2247356176376343,
+                -1.2247357368469238, -1.1920928955078125e-07, 1.2247354984283447,
+            ], [2, 3]);
+
+            const norm = layer_norm(t1, [t1.dims.at(-1)]);
+            compare(norm, target, 1e-3);
+        });
     });
 });


### PR DESCRIPTION
Needed for [nomic-ai/nomic-embed-text-v1.5](https://huggingface.co/nomic-ai/nomic-embed-text-v1.5#transformersjs).

Example usage:
```js
import { pipeline, layer_norm } from '@xenova/transformers';

// Create a feature extraction pipeline
const extractor = await pipeline('feature-extraction', 'nomic-ai/nomic-embed-text-v1.5', {
    quantized: false, // Comment out this line to use the quantized version
});

// Compute sentence embeddings
const texts = ['search_query: What is TSNE?', 'search_query: Who is Laurens van der Maaten?'];
let embeddings = await extractor(texts, { pooling: 'mean' });

const matryoshka_dim = 512;
embeddings = layer_norm(embeddings, [embeddings.dims[1]])
    .slice(null, [0, matryoshka_dim])
    .normalize(2, -1);
console.log(embeddings.tolist());
// [
//   [-0.00518727907910943,   0.06514579057693481,  -0.21559129655361176, ...],
//   [-0.008253306150436401,  0.005108598619699478,   -0.22179779410362244, ...],
// ]
```

Relevant discussion: https://huggingface.co/nomic-ai/nomic-embed-text-v1.5/discussions/4#65cce8d0c52afc14ceac26c2