### PR TITLE
Add support for WavlmForXVector

### DIFF
--- a/scripts/convert.py
+++ b/scripts/convert.py
@@ -99,6 +99,10 @@ MODEL_SPECIFIC_QUANTIZE_PARAMS = {
         'per_channel': False,
         'reduce_range': False,
     },
+    'wavlm': {
+        'per_channel': False,
+        'reduce_range': False,
+    },
 }
 
 MODELS_WITHOUT_TOKENIZERS = [

--- a/scripts/supported_models.py
+++ b/scripts/supported_models.py
@@ -1019,6 +1019,12 @@ SUPPORTED_MODELS = {
             'microsoft/wavlm-base-plus',
             'microsoft/wavlm-large',
         ],
+
+        # Audio XVector (e.g., for speaker verification)
+        'audio-xvector': [
+            'microsoft/wavlm-base-plus-sv',
+            'microsoft/wavlm-base-sv',
+        ],
     },
     'whisper': {
         # Automatic speech recognition

--- a/src/models.js
+++ b/src/models.js
@@ -5524,7 +5524,7 @@ const MODEL_FOR_AUDIO_CLASSIFICATION_MAPPING_NAMES = new Map([
     ['audio-spectrogram-transformer', ['ASTForAudioClassification', ASTForAudioClassification]],
 ]);
 
-const MODEL_FOR_SPEAKER_VERIFICATION_MAPPING_NAMES = new Map([
+const MODEL_FOR_XVECTOR_MAPPING_NAMES = new Map([
     ['wavlm', ['WavLMForXVector', WavLMForXVector]],
 ]);
 
@@ -5568,7 +5568,7 @@ const MODEL_CLASS_TYPE_MAPPING = [
     [MODEL_FOR_AUDIO_CLASSIFICATION_MAPPING_NAMES, MODEL_TYPES.EncoderOnly],
     [MODEL_FOR_TEXT_TO_SPECTROGRAM_MAPPING_NAMES, MODEL_TYPES.Seq2Seq],
     [MODEL_FOR_TEXT_TO_WAVEFORM_MAPPING_NAMES, MODEL_TYPES.EncoderOnly],
-    [MODEL_FOR_SPEAKER_VERIFICATION_MAPPING_NAMES, MODEL_TYPES.EncoderOnly],
+    [MODEL_FOR_XVECTOR_MAPPING_NAMES, MODEL_TYPES.EncoderOnly],
 ];
 
 for (const [mappings, type] of MODEL_CLASS_TYPE_MAPPING) {
@@ -5787,8 +5787,8 @@ export class AutoModelForAudioClassification extends PretrainedMixin {
     static MODEL_CLASS_MAPPINGS = [MODEL_FOR_AUDIO_CLASSIFICATION_MAPPING_NAMES];
 }
 
-export class AutoModelForSpeakerVerification extends PretrainedMixin {
-    static MODEL_CLASS_MAPPINGS = [MODEL_FOR_SPEAKER_VERIFICATION_MAPPING_NAMES];
+export class AutoModelForXVector extends PretrainedMixin {
+    static MODEL_CLASS_MAPPINGS = [MODEL_FOR_XVECTOR_MAPPING_NAMES];
 }
 
 export class AutoModelForDocumentQuestionAnswering extends PretrainedMixin {

--- a/src/models.js
+++ b/src/models.js
@@ -4747,7 +4747,7 @@ export class WavLMForSequenceClassification extends WavLMPreTrainedModel {
  * const audio = await read_audio(url, 16000);
  * const inputs = await processor(audio);
 
- * const model = await AutoModel.from_pretrained('D4ve-R/wavlm-base-plus-sv', {quantized: false});
+ * const model = await AutoModel.from_pretrained('D4ve-R/wavlm-base-plus-sv');
  * const embeddings = await model(inputs);
  * // {
  * //   embeddings: Tensor {

--- a/src/models.js
+++ b/src/models.js
@@ -5524,7 +5524,7 @@ const MODEL_FOR_AUDIO_CLASSIFICATION_MAPPING_NAMES = new Map([
     ['audio-spectrogram-transformer', ['ASTForAudioClassification', ASTForAudioClassification]],
 ]);
 
-const MODEL_FOR_XVECTOR_MAPPING_NAMES = new Map([
+const MODEL_FOR_AUDIO_XVECTOR_MAPPING_NAMES = new Map([
     ['wavlm', ['WavLMForXVector', WavLMForXVector]],
 ]);
 
@@ -5568,7 +5568,7 @@ const MODEL_CLASS_TYPE_MAPPING = [
     [MODEL_FOR_AUDIO_CLASSIFICATION_MAPPING_NAMES, MODEL_TYPES.EncoderOnly],
     [MODEL_FOR_TEXT_TO_SPECTROGRAM_MAPPING_NAMES, MODEL_TYPES.Seq2Seq],
     [MODEL_FOR_TEXT_TO_WAVEFORM_MAPPING_NAMES, MODEL_TYPES.EncoderOnly],
-    [MODEL_FOR_XVECTOR_MAPPING_NAMES, MODEL_TYPES.EncoderOnly],
+    [MODEL_FOR_AUDIO_XVECTOR_MAPPING_NAMES, MODEL_TYPES.EncoderOnly],
 ];
 
 for (const [mappings, type] of MODEL_CLASS_TYPE_MAPPING) {
@@ -5788,7 +5788,7 @@ export class AutoModelForAudioClassification extends PretrainedMixin {
 }
 
 export class AutoModelForXVector extends PretrainedMixin {
-    static MODEL_CLASS_MAPPINGS = [MODEL_FOR_XVECTOR_MAPPING_NAMES];
+    static MODEL_CLASS_MAPPINGS = [MODEL_FOR_AUDIO_XVECTOR_MAPPING_NAMES];
 }
 
 export class AutoModelForDocumentQuestionAnswering extends PretrainedMixin {
@@ -5844,13 +5844,13 @@ export class SequenceClassifierOutput extends ModelOutput {
 }
 
 /**
- * Base class for outputs of x-vector models.
+ * Base class for outputs of XVector models.
  */
 export class XVectorOutput extends ModelOutput {
     /**
      * @param {Object} output The output of the model.
-     * @param {Tensor} output.logits classification (or regression if config.num_labels==1) scores (before SoftMax).
-     * @param {Tensor} output.embeddings The embeddings of the input sequence.
+     * @param {Tensor} output.logits Classification hidden states before AMSoftmax, of shape `(batch_size, config.xvector_output_dim)`.
+     * @param {Tensor} output.embeddings Utterance embeddings used for vector similarity-based retrieval, of shape `(batch_size, config.xvector_output_dim)`.
      */
     constructor({ logits, embeddings }) {
         super();

--- a/src/models.js
+++ b/src/models.js
@@ -4742,24 +4742,26 @@ export class WavLMForSequenceClassification extends WavLMPreTrainedModel {
  * ```javascript
  * import { AutoProcessor, AutoModel, read_audio } from '@xenova/transformers';
  * 
- * const processor = await AutoProcessor.from_pretrained('D4ve-R/wavlm-base-plus-sv');
+ * // Read and preprocess audio
+ * const processor = await AutoProcessor.from_pretrained('Xenova/wavlm-base-plus-sv');
  * const url = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/jfk.wav';
  * const audio = await read_audio(url, 16000);
  * const inputs = await processor(audio);
-
- * const model = await AutoModel.from_pretrained('D4ve-R/wavlm-base-plus-sv');
- * const embeddings = await model(inputs);
+ * 
+ * // Run model with inputs
+ * const model = await AutoModel.from_pretrained('Xenova/wavlm-base-plus-sv');
+ * const outputs = await model(inputs);
  * // {
- * //   embeddings: Tensor {
- * //     dims: [ 1, 512 ],
- * //     type: 'float32',
- * //     data: Float32Array(512) [-0.349443256855011, ...],
- * //     size: 512
- * //   },
  * //   logits: Tensor {
  * //     dims: [ 1, 512 ],
  * //     type: 'float32',
- * //     data: Float32Array(512) [0.022836603224277496, ...],
+ * //     data: Float32Array(512) [0.5847219228744507, ...],
+ * //     size: 512
+ * //   },
+ * //   embeddings: Tensor {
+ * //     dims: [ 1, 512 ],
+ * //     type: 'float32',
+ * //     data: Float32Array(512) [-0.09079201519489288, ...],
  * //     size: 512
  * //   }
  * // }
@@ -4769,7 +4771,7 @@ export class WavLMForXVector extends WavLMPreTrainedModel {
     /**
      * Calls the model on new inputs.
      * @param {Object} model_inputs The inputs to the model.
-     * @returns {Promise<XVectorOutput>} An object containing the model's output logits for sequence classification.
+     * @returns {Promise<XVectorOutput>} An object containing the model's output logits and speaker embeddings.
      */
     async _call(model_inputs) {
         return new XVectorOutput(await super._call(model_inputs));

--- a/src/processors.js
+++ b/src/processors.js
@@ -158,7 +158,7 @@ function post_process_object_detection(outputs, threshold = 0.5, target_sizes = 
 function validate_audio_inputs(audio, feature_extractor) {
     if (!(audio instanceof Float32Array || audio instanceof Float64Array)) {
         throw new Error(
-            `${feature_extractor} expects input to be a Float32Array or a Float64Array, but got ${audio?.constructor?.name ?? typeof audio} instead.` +
+            `${feature_extractor} expects input to be a Float32Array or a Float64Array, but got ${audio?.constructor?.name ?? typeof audio} instead. ` +
             `If using the feature extractor directly, remember to use \`read_audio(url, sampling_rate)\` to obtain the raw audio data of the file/url.`
         )
     }


### PR DESCRIPTION
Adding support for wavlm with xvector head on top.
The onnx version of `microsoft/wavlm-base-plus-sv` can be found at [`D4ve-R/wavlm-base-plus-sv`](https://huggingface.co/D4ve-R/wavlm-base-plus-sv).
Aims to be as close to the python implementation as possible.