### PR TITLE
return stride information in callback from speech recognition

### DIFF
--- a/src/models.js
+++ b/src/models.js
@@ -1135,6 +1135,7 @@ export class PreTrainedModel extends Callable {
 
             // Run callback
             if (generation_config.callback_function) {
+                beams.stride = generation_config.stride;
                 generation_config.callback_function(beams);
             }
         }

--- a/src/pipelines.js
+++ b/src/pipelines.js
@@ -1427,6 +1427,7 @@ export class ZeroShotAudioClassificationPipeline extends (/** @type {new (option
  * @property {number[][]} [kwargs.forced_decoder_ids] A list of pairs of integers which indicates a mapping from generation indices to token indices
  * that will be forced before sampling. For example, [[1, 123]] means the second generated token will always be a token of index 123.
  * @property {number} [num_frames] The number of frames in the input audio.
+ * @property {number[]} [stride] Audio chunk information needed to generate proper timestamps.
  * @typedef {import('./utils/generation.js').GenerationConfigType & AutomaticSpeechRecognitionSpecificParams} AutomaticSpeechRecognitionConfig
  * 
  * @callback AutomaticSpeechRecognitionPipelineCallback Transcribe the audio sequence(s) given as inputs to text.
@@ -1661,6 +1662,7 @@ export class AutomaticSpeechRecognitionPipeline extends (/** @type {new (options
             // Generate for each set of input features
             for (const chunk of chunks) {
                 kwargs.num_frames = Math.floor(chunk.stride[0] / hop_length);
+                kwargs.stride = chunk.stride.map(x => x / sampling_rate);
 
                 // NOTE: doing sequentially for now
                 const data = await this.model.generate(chunk.input_features, kwargs);


### PR DESCRIPTION
In the [whisper web repo](https://github.com/xenova/whisper-web), I noticed that time stamp generation was off while being streamed in - but correct after the transcription is complete. If you look at the demo video, and pause during generation, you will see a 1:02 timestamp for a 1 minute audio clip - which is overwritten upon completion to 0:57.

This is because timestamps are generated correctly when they are passed in as completed chunks, but are off when partial updates are streamed back from the model generation. The callback from completed chunks in ```pipelines.js``` contains stride information, but the callback during partial generation in ```models.js``` does not, and stride information is needed to get correct timestamps from the ```decode_asr``` function in ```tokenizers.js```.

This is not a major issue right now, since the timestamps are only off by 5s, and the error is transient and corrects itself. However I want to make some improvements on whisper-web, like adding [word level timestamps](https://github.com/xenova/whisper-web/issues/17), making decoding more efficient, and adding streaming audio transcriptions from the microphone... and the timestamp discrepancies matter more in those code changes. I can do a workaround to solve this error in a fork of ```whisper-web```, but making the change here is cleaner. If this code change is merged in, the timestamp issue can be mitigated by adding ```last.stride = item.stride;``` after line 134 in ```worker.js``` in ```whisper-web``` - I can open a PR for that
