### PR TITLE
added the missing pip install step

### DIFF
--- a/docs/snippets/4_custom-usage.snippet
+++ b/docs/snippets/4_custom-usage.snippet
@@ -25,6 +25,7 @@ For a full list of available settings, check out the [API Reference](./api/env).
 We recommend using our [conversion script](https://github.com/xenova/transformers.js/blob/main/scripts/convert.py) to convert your PyTorch, TensorFlow, or JAX models to ONNX in a single command. Behind the scenes, it uses [🤗 Optimum](https://huggingface.co/docs/optimum) to perform conversion and quantization of your model.
 
 ```bash
+pip install -r scripts/requirements.txt
 python -m scripts.convert --quantize --model_id <model_name_or_path>
 ```
 


### PR DESCRIPTION
As we're not installing this (typically?) from a pip install itself, the requirements.txt will not be used, resulting in a failure if a different version of ONNX (for example) is installed. Added in the (obvious to everyone but me) step.