### PR TITLE
Support 4bits quantization

### DIFF
--- a/scripts/convert.py
+++ b/scripts/convert.py
@@ -573,7 +573,7 @@ def main():
         if conv_args.reduce_range is not None:
             quantize_config['reduce_range'] = conv_args.reduce_range
 
-        quantize(conv_args.quantize_mode, [
+        quantize(QuantMode(conv_args.quantize_mode), [
             os.path.join(output_model_folder, x)
             for x in os.listdir(output_model_folder)
             if x.endswith('.onnx') and not x.endswith('_quantized.onnx')

--- a/scripts/convert.py
+++ b/scripts/convert.py
@@ -137,7 +137,7 @@ MODELS_WITHOUT_TOKENIZERS = [
 ]
 
 class QuantMode:
-    COMMON = 'common'
+    BIT8 = '8bits'
     BIT4 = '4bits'
     BNB4 = 'bnb4'
 
@@ -166,7 +166,7 @@ class ConversionArguments:
         }
     )
     quantize_mode: str = field(
-        default=QuantMode.COMMON,
+        default=QuantMode.BIT8,
         metadata={
             "help": "Quantization mode to use. Options are: int4, int8, bnb4"
         }
@@ -307,7 +307,7 @@ def quantize(mode, model_names_or_paths, **quantize_kwargs):
 
         save_path = os.path.join(directory_path, f'{file_name_without_extension}_quantized.onnx')
 
-        if mode == QuantMode.COMMON:
+        if mode == QuantMode.BIT8:
             weight_type = QuantType.QUInt8 if 'Conv' in op_types else QuantType.QInt8
 
             quantize_dynamic(
@@ -370,7 +370,7 @@ def main():
     output_model_folder = os.path.join(conv_args.output_parent_dir, model_id)
 
     # Check quantization mode
-    if conv_args.quantize and conv_args.quantize_mode not in (QuantMode.COMMON, QuantMode.BIT4, QuantMode.BNB4):
+    if conv_args.quantize and conv_args.quantize_mode not in (QuantMode.BIT8, QuantMode.BIT4, QuantMode.BNB4):
         raise ValueError(f'Invalid quantization mode: {conv_args.quantize_mode}')
 
     # Create output folder

--- a/scripts/convert.py
+++ b/scripts/convert.py
@@ -286,7 +286,7 @@ def quantize(mode, model_names_or_paths, **quantize_kwargs):
 
     quantize_config = dict(
         **quantize_kwargs,
-        quantize_mode=mode,
+        quantize_mode=mode.value,
         per_model_config={}
     )
 

--- a/scripts/convert.py
+++ b/scripts/convert.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass, field
 from typing import Optional, Set
 from tqdm import tqdm
 from enum import Enum
-from pathlib import Path
 
 from transformers import (
     AutoConfig,

--- a/scripts/convert.py
+++ b/scripts/convert.py
@@ -310,8 +310,9 @@ def quantize(mode, model_names_or_paths, **quantize_kwargs):
         if mode == QuantMode.BIT8:
             weight_type = QuantType.QUInt8 if 'Conv' in op_types else QuantType.QInt8
 
+            del loaded_model
             quantize_dynamic(
-                model_input=loaded_model,
+                model_input=model,
                 model_output=save_path,
                 weight_type=weight_type,
                 #optimize_model=False,


### PR DESCRIPTION
As title.

Notes:
- Execution require `onnxruntime>=1.16.2`
- Convert require `onnxruntime>=1.17.0`
- 4bits currently support CPU / CUDA / WebGPU(future) ([MatMulNBits](https://github.com/search?q=repo%3Amicrosoft%2Fonnxruntime+MatMulNBits&type=code))
- bnb4 currently support CPU / CUDA ([MatMulBnb4](https://github.com/search?q=repo%3Amicrosoft%2Fonnxruntime+BNB4&type=code))