### PR TITLE
Update tokenizer `apply_chat_template` functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.16.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@huggingface/jinja": "^0.2.1",
+        "@huggingface/jinja": "^0.2.2",
         "onnxruntime-web": "1.14.0",
         "sharp": "^0.32.0"
       },
@@ -745,9 +745,9 @@
       }
     },
     "node_modules/@huggingface/jinja": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.2.1.tgz",
-      "integrity": "sha512-HxjVCll8oGfgUQmN91NYWCjfuaQ5mYZkc/BB1gjfp28q3s48yiB5jUEV7BvaRdIAb/+14cNdX8TIdalFykwywA==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.2.2.tgz",
+      "integrity": "sha512-/KPde26khDUIPkTGU82jdtTW9UAuvUTumCAbFs/7giR0SxsvZC4hru51PBvpijH6BVkHcROcvZM/lpy5h1jRRA==",
       "engines": {
         "node": ">=18"
       }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "onnxruntime-web": "1.14.0",
     "sharp": "^0.32.0",
-    "@huggingface/jinja": "^0.2.1"
+    "@huggingface/jinja": "^0.2.2"
   },
   "optionalDependencies": {
     "onnxruntime-node": "1.14.0"

--- a/src/tokenizers.js
+++ b/src/tokenizers.js
@@ -3005,6 +3005,7 @@ export class PreTrainedTokenizer extends Callable {
         truncation = false,
         max_length = null,
         return_tensor = true,
+        ...kwargs
     } = {}) {
 
         chat_template ??= this.chat_template ?? this.default_chat_template;
@@ -3029,6 +3030,7 @@ export class PreTrainedTokenizer extends Callable {
             add_generation_prompt: add_generation_prompt,
 
             ...special_tokens_map,
+            ...kwargs,
         });
 
         if (tokenize) {

--- a/src/tokenizers.js
+++ b/src/tokenizers.js
@@ -4300,6 +4300,9 @@ export class VitsTokenizer extends PreTrainedTokenizer {
         this.decoder = new VitsDecoder({});
     }
 }
+
+export class CohereTokenizer extends PreTrainedTokenizer { }
+
 /**
  * Helper class which is used to instantiate pretrained tokenizers with the `from_pretrained` function.
  * The chosen tokenizer class is determined by the type specified in the tokenizer config.
@@ -4351,6 +4354,7 @@ export class AutoTokenizer {
         VitsTokenizer,
         Qwen2Tokenizer,
         GemmaTokenizer,
+        CohereTokenizer,
 
         // Base case:
         PreTrainedTokenizer,

--- a/src/tokenizers.js
+++ b/src/tokenizers.js
@@ -2995,6 +2995,7 @@ export class PreTrainedTokenizer extends Callable {
      * @param {number} [options.max_length=null] Maximum length (in tokens) to use for padding or truncation. Has no effect if tokenize is false.
      * If not specified, the tokenizer's `max_length` attribute will be used as a default.
      * @param {boolean} [options.return_tensor=true] Whether to return the output as a Tensor or an Array. Has no effect if tokenize is false.
+     * @param {Object} [options.tokenizer_kwargs={}] Additional options to pass to the tokenizer.
      * @returns {string | Tensor | number[]| number[][]} The tokenized output.
      */
     apply_chat_template(conversation, {
@@ -3005,6 +3006,7 @@ export class PreTrainedTokenizer extends Callable {
         truncation = false,
         max_length = null,
         return_tensor = true,
+        tokenizer_kwargs = {},
         ...kwargs
     } = {}) {
 
@@ -3040,6 +3042,7 @@ export class PreTrainedTokenizer extends Callable {
                 truncation,
                 max_length,
                 return_tensor,
+                ...tokenizer_kwargs,
             }).input_ids;
         }
 


### PR DESCRIPTION
This PR adds functionality to support the new [C4AI Command-R tokenizer](https://huggingface.co/CohereForAI/c4ai-command-r-v01).

Example usage:

```js
import { AutoTokenizer } from "@xenova/transformers";

const tokenizer = await AutoTokenizer.from_pretrained("Xenova/c4ai-command-r-v01-tokenizer")

// define conversation input:
const conversation = [
  { role: "user", content: "Whats the biggest penguin in the world?" }
]
// Define tools available for the model to use:
const tools = [
  {
    name: "internet_search",
    description: "Returns a list of relevant document snippets for a textual query retrieved from the internet",
    parameter_definitions: {
      query: {
        description: "Query to search the internet with",
        type: "str",
        required: true
      }
    }
  },
  {
    name: "directly_answer",
    description: "Calls a standard (un-augmented) AI chatbot to generate a response given the conversation history",
    parameter_definitions: {}
  }
]


// render the tool use prompt as a string:
const tool_use_prompt = tokenizer.apply_chat_template(
  conversation,
  {
    chat_template: "tool_use",
    tokenize: false,
    add_generation_prompt: true,
    tools,
  }
)
console.log(tool_use_prompt)
```