### PR TITLE
Improve support of conversational models

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,6 @@ You can refine your search by selecting the task you're interested in (e.g., [te
 
 | Task                     | ID | Description | Supported? |
 |--------------------------|----|-------------|------------|
-| [Conversational](https://huggingface.co/tasks/conversational)           | `conversational`  | Generating conversational text that is relevant, coherent and knowledgable given a prompt. | ❌ |
 | [Fill-Mask](https://huggingface.co/tasks/fill-mask)                     | `fill-mask`   | Masking some of the words in a sentence and predicting which words should replace those masks. | ✅ [(docs)](https://huggingface.co/docs/transformers.js/api/pipelines#module_pipelines.FillMaskPipeline)<br>[(models)](https://huggingface.co/models?pipeline_tag=fill-mask&library=transformers.js) |
 | [Question Answering](https://huggingface.co/tasks/question-answering)   | `question-answering`   | Retrieve the answer to a question from a given text. | ✅ [(docs)](https://huggingface.co/docs/transformers.js/api/pipelines#module_pipelines.QuestionAnsweringPipeline)<br>[(models)](https://huggingface.co/models?pipeline_tag=question-answering&library=transformers.js) |
 | [Sentence Similarity](https://huggingface.co/tasks/sentence-similarity) | `sentence-similarity`  | Determining how similar two texts are. | ✅ [(docs)](https://huggingface.co/docs/transformers.js/api/pipelines#module_pipelines.FeatureExtractionPipeline)<br>[(models)](https://huggingface.co/models?pipeline_tag=feature-extraction&library=transformers.js) |

--- a/docs/snippets/5_supported-tasks.snippet
+++ b/docs/snippets/5_supported-tasks.snippet
@@ -5,7 +5,6 @@
 
 | Task                     | ID | Description | Supported? |
 |--------------------------|----|-------------|------------|
-| [Conversational](https://huggingface.co/tasks/conversational)           | `conversational`  | Generating conversational text that is relevant, coherent and knowledgable given a prompt. | ❌ |
 | [Fill-Mask](https://huggingface.co/tasks/fill-mask)                     | `fill-mask`   | Masking some of the words in a sentence and predicting which words should replace those masks. | ✅ [(docs)](https://huggingface.co/docs/transformers.js/api/pipelines#module_pipelines.FillMaskPipeline)<br>[(models)](https://huggingface.co/models?pipeline_tag=fill-mask&library=transformers.js) |
 | [Question Answering](https://huggingface.co/tasks/question-answering)   | `question-answering`   | Retrieve the answer to a question from a given text. | ✅ [(docs)](https://huggingface.co/docs/transformers.js/api/pipelines#module_pipelines.QuestionAnsweringPipeline)<br>[(models)](https://huggingface.co/models?pipeline_tag=question-answering&library=transformers.js) |
 | [Sentence Similarity](https://huggingface.co/tasks/sentence-similarity) | `sentence-similarity`  | Determining how similar two texts are. | ✅ [(docs)](https://huggingface.co/docs/transformers.js/api/pipelines#module_pipelines.FeatureExtractionPipeline)<br>[(models)](https://huggingface.co/models?pipeline_tag=feature-extraction&library=transformers.js) |

--- a/src/pipelines.js
+++ b/src/pipelines.js
@@ -960,7 +960,7 @@ export class TextGenerationPipeline extends (/** @type {new (options: TextPipeli
         const add_special_tokens = generate_kwargs.add_special_tokens ?? false;
 
         // By default, return full text
-        const return_full_text = !isChatInput
+        const return_full_text = isChatInput
             ? false
             : generate_kwargs.return_full_text ?? true;
 

--- a/src/tokenizers.js
+++ b/src/tokenizers.js
@@ -2429,6 +2429,12 @@ function truncateHelper(item, length) {
 }
 
 
+/**
+ * @typedef {Object} Message
+ * @property {string} role The role of the message (e.g., "user" or "assistant" or "system").
+ * @property {string} content The content of the message.
+ */
+
 export class PreTrainedTokenizer extends Callable {
     return_token_type_ids = false;
 
@@ -2958,12 +2964,6 @@ export class PreTrainedTokenizer extends Callable {
 
         return this._default_chat_template;
     }
-
-    /**
-     * @typedef {Object} Message
-     * @property {string} role The role of the message (e.g., "user" or "assistant" or "system").
-     * @property {string} content The content of the message.
-     */
 
     /**
      * Converts a list of message objects with `"role"` and `"content"` keys to a list of token

--- a/tests/generation.test.js
+++ b/tests/generation.test.js
@@ -147,6 +147,8 @@ describe('Generation parameters', () => {
             'Suddenly,',
         ];
 
+        const generator = await pipeline('text-generation', m(models[2]));
+
         { // return_full_text=false
             const output = await generator(text, {
                 return_full_text: false,

--- a/tests/generation.test.js
+++ b/tests/generation.test.js
@@ -11,6 +11,8 @@ describe('Generation parameters', () => {
     const models = [
         'MBZUAI/LaMini-Flan-T5-77M', // encoder-decoder
         'MBZUAI/LaMini-GPT-124M', // decoder-only
+
+        'Xenova/llama2.c-stories15M', // decoder-only
     ];
 
     // encoder-decoder model
@@ -131,6 +133,37 @@ describe('Generation parameters', () => {
             expect(tokens.length).toBeGreaterThanOrEqual(promptTokens.length + MIN_NEW_TOKENS);
         }
 
+        await generator.dispose();
+
+    }, MAX_TEST_EXECUTION_TIME);
+
+    // decoder-only model
+    it(models[2], async () => {
+        const MAX_NEW_TOKENS = 1;
+
+        const text = [
+            'Once upon a time,',
+            'Lily',
+            'Suddenly,',
+        ];
+
+        { // return_full_text=false
+            const output = await generator(text, {
+                return_full_text: false,
+                max_new_tokens: MAX_NEW_TOKENS,
+                num_beams: 2,
+                num_return_sequences: 2,
+            });
+            const lengths = output.flatMap(
+                x => x.flatMap(
+                    y => generator.tokenizer.encode(y.generated_text.trim(), null, {
+                        add_special_tokens: false,
+                    }).length
+                )
+            ).every(x => x === MAX_NEW_TOKENS);
+
+            expect(lengths).toBe(true);
+        }
         await generator.dispose();
 
     }, MAX_TEST_EXECUTION_TIME);


### PR DESCRIPTION
This PR adds support for passing chat messages (with "role" and "content" properties) to the text-generation pipeline.

**Example:** Chat with `Xenova/Qwen1.5-0.5B-Chat`.

```js
import { pipeline } from '@xenova/transformers';

// Create text-generation pipeline
const generator = await pipeline('text-generation', 'Xenova/Qwen1.5-0.5B-Chat');

// Define the list of messages
const messages = [
    { role: 'system', content: 'You are a helpful assistant.' },
    { role: 'user', content: 'Tell me a funny joke.' }
]

// Generate text
const output = await generator(messages, {
    max_new_tokens: 128,
    do_sample: false,
    return_full_text: false,
})
console.log(output[0].generated_text);
// [
//   { role: 'system', content: 'You are a helpful assistant.' },
//   { role: 'user', content: 'Tell me a funny joke.' },
//   { role: 'assistant', content: "Sure, here's one:\n\nWhy was the math book sad?\n\nBecause it had too many problems.\n\nI hope you found that joke amusing! Do you have any other questions or topics you'd like to discuss?" },
// ]
```