### PR TITLE
maths: switch dot to faster for loop

### DIFF
--- a/src/utils/maths.js
+++ b/src/utils/maths.js
@@ -174,7 +174,11 @@ export function log_softmax(arr) {
  * @returns {number} The dot product of arr1 and arr2.
  */
 export function dot(arr1, arr2) {
-    return arr1.reduce((acc, val, i) => acc + val * arr2[i], 0);
+    let result = 0;
+    for (let i = 0; i < arr1.length; i++) {
+        result += arr1[i] * arr2[i];
+    }
+    return result;
 }
 
 


### PR DESCRIPTION
Tiny optimization; the for loop warms up faster than the reduce.

```js
import { dot } from "@xenova/transformers";

function dotNew(arr1, arr2) {
    let result = 0;
    for (let i = 0; i < arr1.length; i++) {
        result += arr1[i] * arr2[i];
    }
    return result;
}

const random1 = Array.from({ length: 10000 }, () => Array.from({ length: 512 }, () => Math.random()));
const random2 = Array.from({ length: 10000 }, () => Array.from({ length: 512 }, () => Math.random()));

// Replaced with dotNew for second run
console.time("dot");
for (let i = 0; i < 10000; i++) {
    dot(random1[i], random2[i]);
}
console.timeEnd("dot");
```

Output on `node v20.5.1`

```
dot: 43.757ms
dotNew: 11.982ms
```

Of course, eventually they're exactly the same. With 100k elements:
```
dot: 109.57ms
dotNew: 76.428ms
```