### PR TITLE
Add custom task `register_pipeline`

### DIFF
--- a/src/env.js
+++ b/src/env.js
@@ -106,6 +106,8 @@ export const env = {
     localModelPath: localModelPath,
     useFS: FS_AVAILABLE,
 
+    customTasks: {},
+
     /////////////////// Cache settings ///////////////////
     useBrowserCache: WEB_CACHE_AVAILABLE,
 


### PR DESCRIPTION
Following feature request #659

Example use :

```js
import {
  Pipeline,
  read_audio,
  register_pipeline,
  ClapAudioModelWithProjection,
  AutoProcessor,
  pipeline
} from '@xenova/transformers';

class AudioFeatureExtractionPipeline extends Pipeline {
  constructor(options) {
    super(options);
  }
  async _call(input, kwargs = {}) {
    input = await read_audio(input)
    input = await this.processor(input);
    let { audio_embeds } = await this.model(input);
    return audio_embeds
  }
}

register_pipeline('audio-feature-extraction', {
  pipeline: AudioFeatureExtractionPipeline,
  model: ClapAudioModelWithProjection,
  processor: AutoProcessor,
  model_name: 'Xenova/larger_clap_music_and_speech'
})

let pipe = await pipeline('audio-feature-extraction');
let out = await pipe('https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/jfk.wav')
console.log(out)
```