### PR TITLE
Add clearBrowserCache

### DIFF
--- a/src/utils/hub.js
+++ b/src/utils/hub.js
@@ -659,3 +659,15 @@ function pathJoin(...parts) {
     })
     return parts.join('/');
 }
+
+/**
+ * Clear browser cache.
+ *
+ * @returns {Promise<boolean>} Successfully delete cache
+ */
+export async function clearBrowserCache(){
+    if (env.useBrowserCache && typeof caches === 'object') {
+        return await caches.delete('transformers-cache')
+    }
+    else return false
+}


### PR DESCRIPTION
Transformers.js only put data to browser cache, but there is no built-in function to clear browser cache. Would be great to have one