### PR TITLE
Auto rotate image

### DIFF
--- a/src/utils/image.js
+++ b/src/utils/image.js
@@ -39,7 +39,7 @@ if (BROWSER_ENV) {
         const metadata = await img.metadata();
         const rawChannels = metadata.channels;
 
-        let { data, info } = await img.raw().toBuffer({ resolveWithObject: true });
+        let { data, info } = await img.rotate().raw().toBuffer({ resolveWithObject: true });
 
         const newImage = new RawImage(new Uint8ClampedArray(data), info.width, info.height, info.channels);
         if (rawChannels !== undefined && rawChannels !== info.channels) {


### PR DESCRIPTION
Tell Sharp to rotate the image based on the EXIF. Allows proper processing on images taken from phones.