### PR TITLE
v3: wasmPaths relative path

### DIFF
--- a/src/backends/onnx.js
+++ b/src/backends/onnx.js
@@ -71,6 +71,12 @@ export function deviceToExecutionProviders(device) {
  * @returns {Promise<import('onnxruntime-common').InferenceSession>} The ONNX inference session.
  */
 export async function createInferenceSession(buffer, session_options) {
+    if(apis.IS_BROWSER_ENV){
+        let url = env.backends.onnx.wasm.wasmPaths;
+        if(!url.startsWith('http')){
+            env.backends.onnx.wasm.wasmPaths = url[0] == '/' ? location.origin + url : location.href.replace(/[^\/]+$/,'') + url;
+        }
+    }
     return await InferenceSession.create(buffer, session_options);
 }
 


### PR DESCRIPTION
With v3, in web environment, using relative path (eg 'dist', '/dist') for `env.backends.onnx.wasm.wasmPaths`, doesn't seem to work.

```code
Uncaught (in promise) Error: no available backend found. ERR: [wasm] TypeError: Failed to execute 'fetch' on 'WorkerGlobalScope': Failed to parse URL from dist/v3/ort-wasm-simd.jsep.wasm
```

This PR should fix it.