### PR TITLE
v3: fix model fetch DecoderOnly

### DIFF
--- a/src/models.js
+++ b/src/models.js
@@ -690,7 +690,7 @@ export class PreTrainedModel extends Callable {
         if (modelType === MODEL_TYPES.DecoderOnly) {
             info = await Promise.all([
                 constructSessions(pretrained_model_name_or_path, {
-                    model: options.model_file_name ?? 'model',
+                    model: options.model_file_name ?? 'decoder_model_merged',
                 }, options),
                 getModelJSON(pretrained_model_name_or_path, 'generation_config.json', false, options),
             ]);


### PR DESCRIPTION
Small fix
* Closes [404 when trying Qwen in V3 #723](https://github.com/xenova/transformers.js/issues/723)