### PR TITLE
Remove old import from `stream/web` for `ReadableStream`

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,8 +74,7 @@
     "path": false,
     "url": false,
     "sharp": false,
-    "onnxruntime-node": false,
-    "stream/web": false
+    "onnxruntime-node": false
   },
   "publishConfig": {
     "access": "public"

--- a/src/utils/hub.js
+++ b/src/utils/hub.js
@@ -7,15 +7,9 @@
 
 import fs from 'fs';
 import path from 'path';
-import stream from 'stream/web';
 
 import { env } from '../env.js';
 import { dispatchCallback } from './core.js';
-
-if (!globalThis.ReadableStream) {
-    // @ts-ignore
-    globalThis.ReadableStream = stream.ReadableStream; // ReadableStream is not a global with Node 16
-}
 
 /**
  * @typedef {Object} PretrainedOptions Options for loading a pretrained model.     


### PR DESCRIPTION
Node 16 is no longer supported.

Closes #742