### PR TITLE
Update pipelines.js to allow for `token_embeddings` as well

### DIFF
--- a/src/pipelines.js
+++ b/src/pipelines.js
@@ -1255,7 +1255,7 @@ export class FeatureExtractionPipeline extends (/** @type {new (options: TextPip
         // console.log(outputs)
 
         /** @type {Tensor} */
-        let result = outputs.last_hidden_state ?? outputs.logits;
+        let result = outputs.last_hidden_state ?? outputs.logits ?? outputs.token_embeddings;
         if (pooling === 'none') {
             // Skip pooling
         } else if (pooling === 'mean') {

--- a/src/pipelines.js
+++ b/src/pipelines.js
@@ -3283,3 +3283,4 @@ async function loadItems(mapping, model, pretrainedOptions) {
 
     return result;
 }
+

--- a/src/pipelines.js
+++ b/src/pipelines.js
@@ -3283,4 +3283,3 @@ async function loadItems(mapping, model, pretrainedOptions) {
 
     return result;
 }
-


### PR DESCRIPTION
In recent examples of optimum pipeline export the feature extraction pipelines have their output state as `token_embeddings` instead of `last_hidden_state`.

So we should support this as well.