### PR TITLE
Add sequence post processor

### DIFF
--- a/src/tokenizers.js
+++ b/src/tokenizers.js
@@ -1740,6 +1740,10 @@ class ByteLevelPostProcessor extends PostProcessor {
     }
 }
 
+
+/**
+ * A post-processor that applies multiple post-processors in sequence.
+ */
 class PostProcessorSequence extends PostProcessor {
 
     /**

--- a/src/tokenizers.js
+++ b/src/tokenizers.js
@@ -2665,6 +2665,7 @@ export class PreTrainedTokenizer extends Callable {
      * @param {boolean} [options.truncation=null] Whether to truncate the input sequences.
      * @param {number} [options.max_length=null] Maximum length of the returned list and optionally padding length.
      * @param {boolean} [options.return_tensor=true] Whether to return the results as Tensors or arrays.
+     * @param {boolean} [options.return_token_type_ids=null] Whether to return the token type ids.
      * @returns {BatchEncoding} Object to be passed to the model.
      */
     _call(
@@ -2679,6 +2680,7 @@ export class PreTrainedTokenizer extends Callable {
             truncation = null,
             max_length = null,
             return_tensor = true, // Different to HF
+            return_token_type_ids = null,
         } = {},
     ) {
 
@@ -2701,11 +2703,11 @@ export class PreTrainedTokenizer extends Callable {
                 }
 
                 encodedTokens = text.map(
-                    (t, i) => this._encode_plus(t, text_pair[i], { add_special_tokens })
+                    (t, i) => this._encode_plus(t, text_pair[i], { add_special_tokens, return_token_type_ids })
                 )
 
             } else {
-                encodedTokens = text.map(x => this._encode_plus(x, null, { add_special_tokens }));
+                encodedTokens = text.map(x => this._encode_plus(x, null, { add_special_tokens, return_token_type_ids }));
             }
 
         } else {
@@ -2718,7 +2720,7 @@ export class PreTrainedTokenizer extends Callable {
             }
 
             // For single input, we just wrap in an array, and then unwrap later.
-            encodedTokens = [this._encode_plus(text, text_pair, { add_special_tokens })];
+            encodedTokens = [this._encode_plus(text, text_pair, { add_special_tokens, return_token_type_ids })];
         }
         // At this point, tokens is batched: [batch_size, tokens]
         // However, array may be jagged. So, we pad to max_length
@@ -2876,11 +2878,13 @@ export class PreTrainedTokenizer extends Callable {
      * @param {string|null} text_pair The optional second text to encode.
      * @param {Object} options An optional object containing the following properties:
      * @param {boolean} [options.add_special_tokens=true] Whether or not to add the special tokens associated with the corresponding model.
+     * @param {boolean} [options.return_token_type_ids=null] Whether to return token_type_ids.
      * @returns {EncodingSingle} An object containing the encoded text.
      * @private
      */
     _encode_plus(text, text_pair = null, {
         add_special_tokens = true,
+        return_token_type_ids = null,
     } = {}) {
         // Function called by users to encode possibly multiple texts
         const tokens = this._encode_text(text);
@@ -2896,7 +2900,7 @@ export class PreTrainedTokenizer extends Callable {
             input_ids,
             attention_mask: new Array(input_ids.length).fill(1),
         }
-        if (this.return_token_type_ids && combinedTokens.token_type_ids) {
+        if ((return_token_type_ids ?? this.return_token_type_ids) && combinedTokens.token_type_ids) {
             result.token_type_ids = combinedTokens.token_type_ids;
         }
         return result;
@@ -2909,13 +2913,16 @@ export class PreTrainedTokenizer extends Callable {
      * @param {string|null} text_pair The optional second text to encode.
      * @param {Object} options An optional object containing the following properties:
      * @param {boolean} [options.add_special_tokens=true] Whether or not to add the special tokens associated with the corresponding model.
+     * @param {boolean} [options.return_token_type_ids=null] Whether to return token_type_ids.
      * @returns {number[]} An array of token IDs representing the encoded text(s).
      */
     encode(text, text_pair = null, {
         add_special_tokens = true,
+        return_token_type_ids = null,
     } = {}) {
         const { input_ids } = this._encode_plus(text, text_pair, {
             add_special_tokens,
+            return_token_type_ids,
         });
         return input_ids;
     }

--- a/tests/generate_tests.py
+++ b/tests/generate_tests.py
@@ -20,6 +20,7 @@ ADDITIONAL_TOKENIZERS_TO_TEST = {
         'Xenova/llama2-tokenizer',  # Special tokens: normalized=false
         'Xenova/llama2-chat-tokenizer',  # Special tokens: normalized=false
         'hf-internal-testing/llama-code-tokenizer',
+        'Xenova/llama3-tokenizer-new',  # PostProcessor type: Sequence
     ],
     'mpt': [
         'mosaicml/mpt-7b',

--- a/tests/generate_tests.py
+++ b/tests/generate_tests.py
@@ -20,7 +20,9 @@ ADDITIONAL_TOKENIZERS_TO_TEST = {
         'Xenova/llama2-tokenizer',  # Special tokens: normalized=false
         'Xenova/llama2-chat-tokenizer',  # Special tokens: normalized=false
         'hf-internal-testing/llama-code-tokenizer',
-        'Xenova/llama3-tokenizer-new',  # PostProcessor type: Sequence
+
+        # TODO: add back when llama tests are fixed
+        # 'Xenova/llama3-tokenizer-new',  # PostProcessor type: Sequence
     ],
     'mpt': [
         'mosaicml/mpt-7b',
@@ -290,7 +292,7 @@ def generate_tokenizer_tests():
                 # Load tokenizer
                 if model_type == 'llama':
                     # As of 17/12/2023, there are a few issues with the Llama tokenizers in transformers.
-                    # (1) Encoding with fast tokenizer adds whitespace after speical tokens:
+                    # (1) Encoding with fast tokenizer adds whitespace after special tokens:
                     #   - https://github.com/huggingface/transformers/issues/25881
                     #   - https://github.com/huggingface/transformers/issues/26318
                     #   - https://github.com/huggingface/transformers/issues/26455

--- a/tests/tokenizers.test.js
+++ b/tests/tokenizers.test.js
@@ -288,6 +288,44 @@ describe('Token type ids', () => {
         compare(model_inputs, expected);
 
     }, MAX_TEST_EXECUTION_TIME);
+
+    it('should add token type ids if user requests them', async () => {
+        const tokenizer = await AutoTokenizer.from_pretrained('Xenova/llama3-tokenizer-new');
+
+        { // Without text pair
+            const model_inputs = tokenizer(
+                'hello',
+                {
+                    return_tensor: false,
+                    return_token_type_ids: true,
+                }
+            );
+            const expected = {
+                input_ids: [128000, 15339],
+                attention_mask: [1, 1],
+                token_type_ids: [0, 0]
+            }
+            compare(model_inputs, expected);
+        }
+
+        { // With text pair
+            const model_inputs = tokenizer(
+                'hello',
+                {
+                    text_pair: 'world',
+                    return_tensor: false,
+                    return_token_type_ids: true,
+                }
+            );
+            const expected = {
+                input_ids: [128000, 15339, 128000, 14957],
+                attention_mask: [1, 1, 1, 1],
+                token_type_ids: [0, 0, 1, 1]
+            }
+            compare(model_inputs, expected);
+        }
+
+    }, MAX_TEST_EXECUTION_TIME);
 });
 
 describe('Edge cases', () => {


### PR DESCRIPTION
Adds support for updated Llama 3 tokenizer.

Closes #739



Example JavaScript code:
```js
import { AutoTokenizer } from "@xenova/transformers";
const tokenizer = await AutoTokenizer.from_pretrained("Xenova/llama3-tokenizer-new");

console.log(tokenizer.encode('hello world')); // [128000, 15339, 1917]
console.log(tokenizer.encode('hello', 'world')); // [128000, 15339, 128000, 14957]

console.log(tokenizer('hello world', { return_tensor: false })); // { input_ids: [ 128000, 15339, 1917 ], attention_mask: [ 1, 1, 1 ] }
console.log(tokenizer('hello', { text_pair: 'world', return_tensor: false })); // { input_ids: [128000, 15339, 128000, 14957], attention_mask: [1, 1, 1, 1] }

console.log(tokenizer('hello world', { return_token_type_ids: true, return_tensor: false })); // { input_ids: [128000, 15339, 1917], attention_mask: [1, 1, 1], token_type_ids: [0, 0, 0] }
console.log(tokenizer('hello', { text_pair: 'world', return_token_type_ids: true, return_tensor: false })); // { input_ids: [128000, 15339, 128000, 14957], attention_mask: [1, 1, 1, 1], token_type_ids: [0, 0, 1, 1] }
```

Equivalent Python code:
```py
from transformers import AutoTokenizer
tokenizer = AutoTokenizer.from_pretrained('Xenova/llama-3-tokenizer-new')

print(tokenizer.encode('hello world')) # [128000, 15339, 1917]
print(tokenizer.encode('hello', 'world')) # [128000, 15339, 128000, 14957]

print(tokenizer('hello world')) # {'input_ids': [128000, 15339, 1917], 'attention_mask': [1, 1, 1]}
print(tokenizer('hello', 'world')) # {'input_ids': [128000, 15339, 128000, 14957], 'attention_mask': [1, 1, 1, 1]}

print(tokenizer('hello world', return_token_type_ids=True)) # {'input_ids': [128000, 15339, 1917], 'token_type_ids': [0, 0, 0], 'attention_mask': [1, 1, 1]}
print(tokenizer('hello', 'world', return_token_type_ids=True)) # {'input_ids': [128000, 15339, 128000, 14957], 'token_type_ids': [0, 0, 1, 1], 'attention_mask': [1, 1, 1, 1]}
```
