### PR TITLE
Added support for client-side loading of gated remote files (via user provided token)

### DIFF
--- a/src/env.js
+++ b/src/env.js
@@ -92,6 +92,9 @@ const localModelPath = RUNNING_LOCALLY
  * allowing users to set these variables if they want to.
  * @property {boolean} allowRemoteModels Whether to allow loading of remote files, defaults to `true`.
  * If set to `false`, it will have the same effect as setting `local_files_only=true` when loading pipelines, models, tokenizers, processors, etc.
+ * @property {boolean} allowClientSideRemoteGatedModels Whether to allow loading of gated remote files on the client side, defaults to `false`.
+ * If set to `true`, it will be necessary to set userHFToken to load gated models.
+ * @property {string} userHFToken The user's Hugging Face API token to use when loading gated models from the client side.
  * @property {string} remoteHost Host URL to load models from. Defaults to the Hugging Face Hub.
  * @property {string} remotePathTemplate Path template to fill in and append to `remoteHost` when loading models.
  * @property {boolean} allowLocalModels Whether to allow loading of local files, defaults to `false` if running in-browser, and `true` otherwise.
@@ -125,6 +128,9 @@ export const env = {
     allowRemoteModels: true,
     remoteHost: 'https://huggingface.co/',
     remotePathTemplate: '{model}/resolve/{revision}/',
+
+    allowClientSideRemoteGatedModels: false,
+    userHFToken: '',
 
     allowLocalModels: !IS_BROWSER_ENV,
     localModelPath: localModelPath,

--- a/src/utils/hub.js
+++ b/src/utils/hub.js
@@ -191,7 +191,7 @@ export async function getFile(urlOrPath) {
     if (env.useFS && !isValidUrl(urlOrPath, ['http:', 'https:', 'blob:'])) {
         return new FileResponse(urlOrPath);
 
-    } else if (typeof process !== 'undefined' && process?.release?.name === 'node') {
+    } else if (typeof process !== 'undefined' && (process?.release?.name === 'node' || env.allowClientSideRemoteGatedModels)) {
         const IS_CI = !!process.env?.TESTING_REMOTELY;
         const version = env.version;
 
@@ -204,7 +204,7 @@ export async function getFile(urlOrPath) {
             // If an access token is present in the environment variables,
             // we add it to the request headers.
             // NOTE: We keep `HF_ACCESS_TOKEN` for backwards compatibility (as a fallback).
-            const token = process.env?.HF_TOKEN ?? process.env?.HF_ACCESS_TOKEN;
+            const token = (process?.release?.name === 'node') ? (process?.env?.HF_TOKEN ?? process.env?.HF_ACCESS_TOKEN) : (env.allowClientSideRemoteGatedModels ? env.userHFToken : undefined);
             if (token) {
                 headers.set('Authorization', `Bearer ${token}`);
             }


### PR DESCRIPTION
I'm building a client side app that needs to be able to pull gated models. The token used is requested from the user. Added support for this to transformers.js