### PR TITLE
no redeclaration of reserved __dirname

### DIFF
--- a/src/env.js
+++ b/src/env.js
@@ -38,19 +38,20 @@ const PATH_AVAILABLE = !isEmpty(path); // check if path is available
 
 const RUNNING_LOCALLY = FS_AVAILABLE && PATH_AVAILABLE;
 
-const __dirname = RUNNING_LOCALLY
+// __dirname is reserved so we go with dirname__ instead.
+const dirname__ = RUNNING_LOCALLY
     ? path.dirname(path.dirname(url.fileURLToPath(import.meta.url)))
     : './';
 
 // Only used for environments with access to file system
 const DEFAULT_CACHE_DIR = RUNNING_LOCALLY
-    ? path.join(__dirname, '/.cache/')
+    ? path.join(dirname__, '/.cache/')
     : null;
 
 // Set local model path, based on available APIs
 const DEFAULT_LOCAL_MODEL_PATH = '/models/';
 const localModelPath = RUNNING_LOCALLY
-    ? path.join(__dirname, DEFAULT_LOCAL_MODEL_PATH)
+    ? path.join(dirname__, DEFAULT_LOCAL_MODEL_PATH)
     : DEFAULT_LOCAL_MODEL_PATH;
 
 if (onnx_env?.wasm) {
@@ -59,7 +60,7 @@ if (onnx_env?.wasm) {
     // We use remote wasm files by default to make it easier for newer users.
     // In practice, users should probably self-host the necessary .wasm files.
     onnx_env.wasm.wasmPaths = RUNNING_LOCALLY
-        ? path.join(__dirname, '/dist/')
+        ? path.join(dirname__, '/dist/')
         : `https://cdn.jsdelivr.net/npm/@xenova/transformers@${VERSION}/dist/`;
 }
 
@@ -94,7 +95,7 @@ export const env = {
         tfjs: {},
     },
 
-    __dirname,
+    __dirname: dirname__,
     version: VERSION,
 
     /////////////////// Model settings ///////////////////

--- a/src/env.js
+++ b/src/env.js
@@ -38,7 +38,7 @@ const PATH_AVAILABLE = !isEmpty(path); // check if path is available
 
 const RUNNING_LOCALLY = FS_AVAILABLE && PATH_AVAILABLE;
 
-// __dirname is reserved so we go with dirname__ instead.
+// __dirname is reserved so we use dirname__ instead.
 const dirname__ = RUNNING_LOCALLY
     ? path.dirname(path.dirname(url.fileURLToPath(import.meta.url)))
     : './';


### PR DESCRIPTION
Running `jest` with this package crashes because of redeclaration of reserved keyword `__dirname`.

This PR renames it to `dirname__`.