### PR TITLE
Implement numerically stable log_softmax()

### DIFF
--- a/src/utils/maths.js
+++ b/src/utils/maths.js
@@ -162,8 +162,10 @@ export function log_softmax(arr) {
     const maxVal = max(arr)[0];
 
     // Compute the sum of the exponentials
-    // @ts-ignore
-    const sumExps = arr.reduce((acc, val) => acc + Math.exp(val - maxVal), 0);
+    let sumExps = 0;
+    for(let i = 0; i < arr.length; ++i) {
+        sumExps += Math.exp(arr[i] - maxVal);
+    }
 
     // Compute the log of the sum
     const logSum = Math.log(sumExps);

--- a/src/utils/maths.js
+++ b/src/utils/maths.js
@@ -158,11 +158,18 @@ export function softmax(arr) {
  * @returns {T} The resulting log_softmax array.
  */
 export function log_softmax(arr) {
-    // Compute the softmax values
-    const softmaxArr = softmax(arr);
+    // Compute the maximum value in the array
+    const maxVal = max(arr)[0];
 
-    // Apply log formula to each element
-    const logSoftmaxArr = softmaxArr.map(x => Math.log(x));
+    // Compute the sum of the exponentials
+    // @ts-ignore
+    const sumExps = arr.reduce((acc, val) => acc + Math.exp(val - maxVal), 0);
+
+    // Compute the log of the sum
+    const logSum = Math.log(sumExps);
+
+    // Compute the softmax values
+    const logSoftmaxArr = arr.map(x => x - maxVal - logSum);
 
     return /** @type {T} */(logSoftmaxArr);
 }

--- a/tests/maths.test.js
+++ b/tests/maths.test.js
@@ -2,7 +2,7 @@
 import { compare } from './test_utils.js';
 
 import { getFile } from '../src/utils/hub.js';
-import { FFT, medianFilter, bankers_round } from '../src/utils/maths.js';
+import { FFT, medianFilter, bankers_round, log_softmax } from '../src/utils/maths.js';
 
 
 const fft = (arr, complex = false) => {
@@ -135,5 +135,22 @@ describe('Mathematical operations', () => {
 
             });
         }
+    });
+
+    describe('log softmax', () => {
+        // Should match output of scipy log_softmax
+        it('should compute log softmax correctly for usual values', () => {
+            const input = [0, 1, 2, 3];
+            const expected = [-3.4401896985611953, -2.4401896985611953, -1.4401896985611953, -0.44018969856119533];
+            const output = log_softmax(input);
+            compare(output, expected, 1e-13);
+        });
+
+        it('should compute log softmax correctly for values with large differences', () => {
+            const input = [1000, 1];
+            const expected = [0, -999];
+            const output = log_softmax(input);
+            compare(output, expected, 1e-13);
+        });
     });
 });


### PR DESCRIPTION
A numerically stable implementation of `log_softmax()`. It's similar to the current implementation of `softmax()` and is what's used in PyTorch and SciPy too.

```javascript
log_softmax([1000,1])

// Current implementation
// > Array [ 0, -Infinity ]

// Proposed implementation
// > Array [ 0, -999 ]
```