### PR TITLE
Initial WebNN Support

### DIFF
--- a/src/backends/onnx.js
+++ b/src/backends/onnx.js
@@ -21,7 +21,7 @@ import { env, apis } from '../env.js';
 // NOTE: Import order matters here. We need to import `onnxruntime-node` before `onnxruntime-web`.
 // In either case, we select the default export if it exists, otherwise we use the named export.
 import * as ONNX_NODE from 'onnxruntime-node';
-import * as ONNX_WEB from 'onnxruntime-web/webgpu';
+import * as ONNX_WEB from 'onnxruntime-web/all';
 
 export { Tensor } from 'onnxruntime-common';
 
@@ -39,6 +39,9 @@ if (apis.IS_NODE_ENV) {
     ONNX = ONNX_WEB;
     if (apis.IS_WEBGPU_AVAILABLE) {
         supportedExecutionProviders.push('webgpu');
+    }
+    if(apis.IS_WEBNN_AVAILABLE) {
+        supportedExecutionProviders.push('webnn');
     }
     supportedExecutionProviders.push('wasm');
     defaultExecutionProviders = ['wasm'];

--- a/src/env.js
+++ b/src/env.js
@@ -33,6 +33,7 @@ const IS_BROWSER_ENV = typeof self !== 'undefined';
 const IS_WEBWORKER_ENV = IS_BROWSER_ENV && self.constructor.name === 'DedicatedWorkerGlobalScope';
 const IS_WEB_CACHE_AVAILABLE = IS_BROWSER_ENV && 'caches' in self;
 const IS_WEBGPU_AVAILABLE = typeof navigator !== 'undefined' && 'gpu' in navigator;
+const IS_WEBNN_AVAILABLE = typeof navigator !== 'undefined' && 'ml' in navigator;
 
 const IS_PROCESS_AVAILABLE = typeof process !== 'undefined';
 const IS_NODE_ENV = IS_PROCESS_AVAILABLE && process?.release?.name === 'node';
@@ -54,6 +55,9 @@ export const apis = Object.freeze({
 
     /** Whether the WebGPU API is available */
     IS_WEBGPU_AVAILABLE,
+
+    /** Whether the WebNN API is available */
+    IS_WEBNN_AVAILABLE,
 
     /** Whether the Node.js process API is available */
     IS_PROCESS_AVAILABLE,

--- a/src/utils/devices.js
+++ b/src/utils/devices.js
@@ -4,6 +4,7 @@ export const DEVICE_TYPES = Object.freeze({
     gpu: 'gpu',
     wasm: 'wasm',
     webgpu: 'webgpu',
+    webnn: 'webnn',
 });
 
 /**

--- a/src/utils/dtypes.js
+++ b/src/utils/dtypes.js
@@ -47,6 +47,7 @@ export const DEFAULT_DEVICE_DTYPE_MAPPING = Object.freeze({
     [DEVICE_TYPES.gpu]: DATA_TYPES.fp32,
     [DEVICE_TYPES.wasm]: DATA_TYPES.q8,
     [DEVICE_TYPES.webgpu]: DATA_TYPES.fp32,
+    [DEVICE_TYPES.webnn]: DATA_TYPES.fp32,
 });
 
 /** @type {Record<DataType, string>} */


### PR DESCRIPTION
This is the initial PR to support [WebNN API](https://webnn.dev).

### User Code

```
    import { pipeline } from '@huggingface/transformers';

    let dataType = 'fp16';
    let provider = 'webnn';
    let deviceType = 'gpu';

    let options = {
      dtype: dataType,
      device: provider,
      session_options: {
        executionProviders: [
          {
            name: provider,
            deviceType: deviceType
          },
        ],
        freeDimensionOverrides: {
          batch_size: 1,
          num_channels: 3,
          height: 224,
          width: 224
        }
      },
    };

    // Create an image classification pipeline
    const classifier = await pipeline('image-classification', 'xenova/resnet-50', options);
    const url = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/tiger.jpg';
    const output = await classifier(url);
    // [
    //   { "label": "tiger, Panthera tigris", "score": 0.9231255054473877 },
    //   { "label": "tiger cat", "score": 0.07358699291944504 },
    //   { "label": "jaguar, panther, Panthera onca, Felis onca", "score": 0.00047683052252978086 },
    //   { "label": "leopard, Panthera pardus", "score": 0.00017269655654672533 },
    //   { "label": "lynx, catamount", "score": 0.00015724201512057334 }
    // ]
```

### WebNN Installation Guide

WebNN is being rapidly implemented in browsers. Before it formally ships, WebNN requires a compatible browser to run, and Windows* 11 v21H2 (DML 1.6.0) or higher.

- Download the latest [Google Chrome Canary](https://google.com/chrome/canary) or [Microsoft Edge Canary](https://www.microsoft.com/edge/download/insider) browser
- To enable WebNN, in your browser address bar, enter `about://flags`, and then press Enter. An Experiments page opens
- In the Search flags box, enter `webnn`. `Enables WebNN API` appears
- In the drop-down menu, select `Enabled`
- Relaunch your browser

### Known Issue

From Transformers.js perspective, it's better to improve the following float16 check code (current via WebGPU and WebGPU shader-f16) since fp16 support is not GPU device only.

- https://github.com/xenova/transformers.js/blob/v3/src/models.js#L178
- https://github.com/xenova/transformers.js/blob/v3/src/utils/dtypes.js#L12

@honry @huningxin @xenova PTAL.





