### PR TITLE
Fix missing CSS and a broken link in the Vanilla JS application tutorial

### DIFF
--- a/docs/source/tutorials/vanilla-js.md
+++ b/docs/source/tutorials/vanilla-js.md
@@ -123,7 +123,7 @@ const status = document.getElementById("status");
 
 ## Step 3: Create an object detection pipeline
 
-We’re finally ready to create our object detection pipeline! As a reminder, a [pipeline](./pipelines). is a high-level interface provided by the library to perform a specific task. In our case, we will instantiate an object detection pipeline with the `pipeline()` helper function.
+We’re finally ready to create our object detection pipeline! As a reminder, a [pipeline](../pipelines). is a high-level interface provided by the library to perform a specific task. In our case, we will instantiate an object detection pipeline with the `pipeline()` helper function.
 
 Since this can take some time (especially the first time when we have to download the ~40MB model), we first update the `status` paragraph so that the user knows that we’re about to load the model.
 

--- a/docs/source/tutorials/vanilla-js.md
+++ b/docs/source/tutorials/vanilla-js.md
@@ -57,7 +57,6 @@ body {
 .custom-file-upload {
     display: flex;
     align-items: center;
-    cursor: pointer;
     gap: 10px;
     border: 2px solid black;
     padding: 8px 16px;
@@ -269,14 +268,19 @@ The bounding box and label span also need some styling, so add the following to 
 
 ```css
 .bounding-box {
-  position: absolute;
-  box-sizing: border-box;
+    position: absolute;
+    box-sizing: border-box;
+    border-width: 2px;
+    border-style: solid;
 }
 
 .bounding-box-label {
-  position: absolute;
-  color: white;
-  font-size: 12px;
+    color: white;
+    position: absolute;
+    font-size: 12px;
+    margin-top: -16px;
+    margin-left: -2px;
+    padding: 1px;
 }
 ```
 


### PR DESCRIPTION
Hi, 
The Vanilla Javascript tutorial is great! 

While I was working on it, I found the border boxes don't display, when you run the completed code. If you look at the provided [Source code](https://github.com/xenova/transformers.js/blob/main/examples/vanilla-js/style.css#L46) you will see the missing CSS fields.  This PR adds them to the tutorial.

Additionally. I notice a broken link for the pipeline  and a minor CSS duplication.  This PR addresses those issues too.

I hope this helps the community and I look forward to hearing your feedback!