### PR TITLE
Add option to maintain aspect ratio on resize

### DIFF
--- a/src/utils/core.js
+++ b/src/utils/core.js
@@ -1,10 +1,10 @@
 
 /**
  * @file Core utility functions/classes for Transformers.js.
- * 
+ *
  * These are only used internally, meaning an end-user shouldn't
  * need to access anything here.
- * 
+ *
  * @module utils/core
  */
 
@@ -46,7 +46,7 @@ export function escapeRegExp(string) {
  * Check if a value is a typed array.
  * @param {*} val The value to check.
  * @returns {boolean} True if the value is a `TypedArray`, false otherwise.
- * 
+ *
  * Adapted from https://stackoverflow.com/a/71091338/13989043
  */
 export function isTypedArray(val) {
@@ -61,6 +61,15 @@ export function isTypedArray(val) {
  */
 export function isIntegralNumber(x) {
     return Number.isInteger(x) || typeof x === 'bigint'
+}
+
+/**
+ * Determine if a provided width or height is nullish.
+ * @param {*} x The value to check.
+ * @returns {boolean} True if the value is `null`, `undefined` or `-1`, false otherwise.
+ */
+export function isNullishDimension(x) {
+    return x === null || x === undefined || x === -1 || x === '-1';
 }
 
 /**
@@ -132,9 +141,9 @@ export function calculateReflectOffset(i, w) {
 }
 
 /**
- * 
- * @param {Object} o 
- * @param {string[]} props 
+ *
+ * @param {Object} o
+ * @param {string[]} props
  * @returns {Object}
  */
 export function pick(o, props) {
@@ -151,7 +160,7 @@ export function pick(o, props) {
 /**
  * Calculate the length of a string, taking multi-byte characters into account.
  * This mimics the behavior of Python's `len` function.
- * @param {string} s The string to calculate the length of. 
+ * @param {string} s The string to calculate the length of.
  * @returns {number} The length of the string.
  */
 export function len(s) {

--- a/tests/utils/utils.test.js
+++ b/tests/utils/utils.test.js
@@ -1,5 +1,6 @@
 import { AutoProcessor, hamming, hanning, mel_filter_bank } from "../../src/transformers.js";
 import { getFile } from "../../src/utils/hub.js";
+import { RawImage } from "../../src/utils/image.js";
 
 import { MAX_TEST_EXECUTION_TIME } from "../init.js";
 import { compare } from "../test_utils.js";
@@ -57,6 +58,36 @@ describe("Utilities", () => {
       const blobUrl = URL.createObjectURL(blob);
       const data = await getFile(blobUrl);
       expect(await data.text()).toBe("Hello, world!");
+    });
+  });
+
+  describe("Image utilities", () => {
+    it("Read image from URL", async () => {
+      const image = await RawImage.fromURL("https://picsum.photos/300/200");
+      expect(image.width).toBe(300);
+      expect(image.height).toBe(200);
+      expect(image.channels).toBe(3);
+    });
+
+    it("Can resize image", async () => {
+      const image = await RawImage.fromURL("https://picsum.photos/300/200");
+      const resized = await image.resize(150, 100);
+      expect(resized.width).toBe(150);
+      expect(resized.height).toBe(100);
+    });
+
+    it("Can resize with aspect ratio", async () => {
+      const image = await RawImage.fromURL("https://picsum.photos/300/200");
+      const resized = await image.resize(150, null);
+      expect(resized.width).toBe(150);
+      expect(resized.height).toBe(100);
+    });
+
+    it("Returns original image if width and height are null", async () => {
+      const image = await RawImage.fromURL("https://picsum.photos/300/200");
+      const resized = await image.resize(null, null);
+      expect(resized.width).toBe(300);
+      expect(resized.height).toBe(200);
     });
   });
 });


### PR DESCRIPTION
In some cases it is required to resize an image, but maintain the aspect ratio.  
This is usually because we want to pad the image.

Here's an example of something I was thinking of.
```js
const image = await RawImage.fromURL("https://picsum.photos/600/400");
const resized = await image.resize(300, null); // 300x200
const padHeight = (300 - image.height) / 2;
const padded = await image.pad([0, 0, padHeight, padHeight]); // 300x300
```

In this example, we resize the image, maintain the aspect ratio and then pad either side.